### PR TITLE
Generate a new webhook on app rename

### DIFF
--- a/src/datastore/AppsDataStore.ts
+++ b/src/datastore/AppsDataStore.ts
@@ -208,13 +208,32 @@ class AppsDataStore {
         }
     }
 
-    renameApp(oldAppName: string, newAppName: string) {
+    renameApp(
+        authenticator: Authenticator,
+        oldAppName: string,
+        newAppName: string
+    ) {
         const self = this
 
         return Promise.resolve()
             .then(function() {
                 self.nameAllowedOrThrow(newAppName)
                 return self.getAppDefinition(oldAppName)
+            })
+            .then(function(appData) {
+                if (appData.appPushWebhook && appData.appPushWebhook.pushWebhookToken) {
+                    const tokenVersion = uuid()
+                    return authenticator.getAppPushWebhookToken(
+                        newAppName,
+                        tokenVersion
+                    ).then((val) => {
+                        appData.appPushWebhook!.pushWebhookToken = val
+                        appData.appPushWebhook!.tokenVersion = tokenVersion
+                        return appData
+                    })
+                }
+
+                return appData
             })
             .then(function(appData) {
                 if (appData.appName) appData.appName = newAppName

--- a/src/user/ServiceManager.ts
+++ b/src/user/ServiceManager.ts
@@ -427,7 +427,7 @@ class ServiceManager {
             .then(function() {
                 return dataStore
                     .getAppsDataStore()
-                    .renameApp(oldAppName, newAppName)
+                    .renameApp(self.authenticator, oldAppName, newAppName)
             })
             .then(function() {
                 return self.ensureServiceInitedAndUpdated(newAppName)


### PR DESCRIPTION
Generates a new webook token when renaming the app
Returns an error if the trigger endpoint can't extract values from the token

Somewhere we should message the user that they need to update the webhook on any external service that depends on it.

Relates to #490 
