### PR TITLE
Fixed image name parsing when using ports

### DIFF
--- a/src/docker/DockerApi.ts
+++ b/src/docker/DockerApi.ts
@@ -5,13 +5,10 @@ import CaptainConstants = require('../utils/CaptainConstants')
 import Logger = require('../utils/Logger')
 import EnvVars = require('../utils/EnvVars')
 import BuildLog = require('../user/BuildLog')
-import {
-    IDockerApiPort,
-    IDockerContainerResource,
-    VolumesTypes,
-} from '../models/OtherTypes'
 import DockerService from '../models/DockerService'
+import { IDockerApiPort, IDockerContainerResource, VolumesTypes } from '../models/OtherTypes'
 import Utils from '../utils/Utils'
+const dockerodeUtils = require('dockerode/lib/util')
 
 const Base64 = Base64Provider.Base64
 
@@ -301,15 +298,14 @@ class DockerApi {
     ) {
         const self = this
 
-        const nameAndTag = imageNameIncludingTag.split(':')
-
-        const tag = nameAndTag[1] || 'latest'
-        const imageName = nameAndTag[0]
+        const { repository, tag } = dockerodeUtils.parseRepositoryTag(
+            imageNameIncludingTag
+        )
 
         return Promise.resolve()
             .then(function() {
                 return self.dockerode.createImage({
-                    fromImage: imageName,
+                    fromImage: repository,
                     tag: tag,
                     authconfig: authObj,
                 })

--- a/src/docker/DockerApi.ts
+++ b/src/docker/DockerApi.ts
@@ -306,7 +306,7 @@ class DockerApi {
             .then(function() {
                 return self.dockerode.createImage({
                     fromImage: repository,
-                    tag: tag,
+                    tag: tag || 'latest',
                     authconfig: authObj,
                 })
             })


### PR DESCRIPTION
Problem: Caprover cannot read from private registries if imageName has a port as seen in #454

Cause: The `pullImage()` method in `DockerApi.ts` is not parsing the image name correctly because it assumes only one colon in the string (ports would introduce a second colon).

Solution: Refactor the Docker image string parsing more efficiently. Luckily, the _dockerode_ package, which is already a dependency, has a utility function that does precisely this. Let's use that!