### PR TITLE
Add missing step for running environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,11 @@ or your local machine itself. Needless to say, Docker is required (same minimum 
 > Docker for Mac users: You need to add `/captain` to shared paths.  
 > To do so, click on the Docker icon -> Preferences -> File Sharing and add `/captain`
 
-Log in to your machine, clone the git repo, go to `app-backend` directory and run the following lines:
+Log in to your machine, clone the git repo and run the following lines:
 
 ```bash
 $   npm install
+$   npm run build
 $   ./dev-scripts/dev-clean-run-as-dev.sh
 ```
 You are good to go! You can run the following line to see the logs for the back-end service.


### PR DESCRIPTION
It seems that we have to first build the project before running the dev script.

Also, I had to manually initialize a docker swarm, but since I had other errors, I'm not sure that it's always the case