### PR TITLE
Remove unnecessary connection to Google from build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,3 @@ npm-debug.log
 .DS_Store
 /.project
 
-# docker cache-busting
-.cachebust

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ npm-debug.log
 .DS_Store
 /.project
 
+# docker cache-busting
+.cachebust

--- a/dev-scripts/build_and_push_edge.sh
+++ b/dev-scripts/build_and_push_edge.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-date > .cachebust
-docker build -t caprover/caprover-edge:latest -f dockerfile-captain.edge .
+docker build --build-arg CACHE_DATE="$(date)" -t caprover/caprover-edge:latest -f dockerfile-captain.edge .
 docker tag caprover/caprover-edge:latest caprover/caprover-edge:0.0.1
 docker push caprover/caprover-edge:latest
 docker push caprover/caprover-edge:0.0.1

--- a/dev-scripts/build_and_push_edge.sh
+++ b/dev-scripts/build_and_push_edge.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+date > .cachebust
 docker build -t caprover/caprover-edge:latest -f dockerfile-captain.edge .
 docker tag caprover/caprover-edge:latest caprover/caprover-edge:0.0.1
 docker push caprover/caprover-edge:latest

--- a/dockerfile-captain.edge
+++ b/dockerfile-captain.edge
@@ -18,8 +18,8 @@ RUN npm install --production && \
 
 # Build frontend code
 
- # This quick hack invalidates the cache
-ADD https://www.google.com /time.now
+# This quick hack invalidates the cache
+ADD .cachebust /.cachebust
 
 RUN mkdir -p /usr/src/app-frontend && cd /usr/src/app-frontend && \
     git clone https://github.com/githubsaturn/caprover-frontend.git && \

--- a/dockerfile-captain.edge
+++ b/dockerfile-captain.edge
@@ -17,8 +17,10 @@ RUN npm install --production && \
 
 # Build frontend code
 
-# This quick hack invalidates the cache
-ADD .cachebust /.cachebust
+# This quick hack invalidates the cache for everything below
+# by specifying it as a build arg to `docker build`
+# https://github.com/moby/moby/issues/22832
+ARG CACHE_DATE=whatever
 
 RUN mkdir -p /usr/src/app-frontend && cd /usr/src/app-frontend && \
     git clone https://github.com/githubsaturn/caprover-frontend.git && \


### PR DESCRIPTION
This network request to Google is unnecessary and can be replaced by a local-only solution.