### PR TITLE
Enforce the same TLS settings for all TLS vhosts

### DIFF
--- a/template/root-nginx-conf.ejs
+++ b/template/root-nginx-conf.ejs
@@ -9,6 +9,11 @@
         listen              443 ssl;
         ssl_certificate     <%-fake.crtPath%>;
         ssl_certificate_key <%-fake.keyPath%>;
+        
+        # Mozilla Intermediate configuration. tweak to your needs.
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+        ssl_prefer_server_ciphers off;
 
         server_name  _;
 
@@ -117,6 +122,11 @@
         listen              443 ssl;
         ssl_certificate     <%-registry.crtPath%>;
         ssl_certificate_key <%-registry.keyPath%>;
+        
+        # Mozilla Intermediate configuration. tweak to your needs.
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+        ssl_prefer_server_ciphers off;
     <%
         }
     %>


### PR DESCRIPTION
The default TLS settings (disabling tls1.0 and 1.1) chosen by CapRover should be applied to the catchall virtualhost as well as the embedded registry.