### PR TITLE
fix append ssh

### DIFF
--- a/src/utils/GitHelper.ts
+++ b/src/utils/GitHelper.ts
@@ -68,7 +68,7 @@ export default class GitHelper {
                             '--recursive',
                             '-b',
                             branch,
-                            `ssh://${REPO_GIT_PATH}`,
+                            REPO_GIT_PATH,
                             directory,
                         ])
                 })


### PR DESCRIPTION
It is no longer necessary prepend "ssh://" as sanitizeRepoPathSsh (with e5dd3346) returns already in the correct format