### PR TITLE
Add http2 support for default nginx script

### DIFF
--- a/template/server-block-conf.ejs
+++ b/template/server-block-conf.ejs
@@ -36,7 +36,7 @@ server {
     }
     if (s.hasSsl) {
     %>
-        listen              443 ssl;
+        listen              443 ssl http2;
         ssl_certificate     <%-s.crtPath%>;
         ssl_certificate_key <%-s.keyPath%>;
 


### PR DESCRIPTION
Adds http2 support for the default nginx script. Http 2 is a backwards compatible upgrade from http 1.1, usable on sites with https and improves load times by uncapping the number of concurrent requests the browser can make for assets, endpoints, etc.

I verified on one of my sites, this is all it takes to enable http 2.