### PR TITLE
Don't emit NGINX version on err pages and in the Server response header

### DIFF
--- a/template/base-nginx-conf.ejs
+++ b/template/base-nginx-conf.ejs
@@ -38,6 +38,9 @@ http {
 
     server_names_hash_bucket_size 128;
 
+    # Don't emit NGINX version on error pages and in the “Server” response header field.
+    server_tokens off;
+
     #gzip  on;
 
     include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
Emitting the NGINX version in the header or on error pages can be a security concern for websites being scanned for NGINX versions with known vulnerabilities.

Hiding this seems like a reasonable default as the benefit of showing it is mostly only useful for debugging purposes and in that case this directive can be removed manually by editing the NGINX conf in Settings.

This doesn't disable the `Server` header entirely, which means it can still be determined someone is running NGINX (to change this requires additional out-of-scope work), but this at least hides the version of NGINX the site is using.