### PR TITLE
Fixed Nginx's force SSL redirect URL

### DIFF
--- a/template/server-block-conf.ejs
+++ b/template/server-block-conf.ejs
@@ -18,7 +18,7 @@ if (s.forceSsl) {
         }
 
         location / {
-            return 302 https://$http_host$request_uri$is_args$query_string;
+            return 302 https://$http_host$request_uri;
         }
     }
 <%


### PR DESCRIPTION
If you have checked `Force HTTPS by redirecting all HTTP traffic to HTTPS`

Before Fix:

```
curl -i "http://app.example.com/path?var=abc"
HTTP/1.1 302 Moved Temporarily
Location: https://app.example.com/path?var=abc?var=abc
```

After Fix:

```
curl -i "http://app.example.com/path?var=abc"
HTTP/1.1 302 Moved Temporarily
Location: https://app.example.com/path?var=abc
```