### PR TITLE
Release  1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 -   TBD
 
+## [1.8.2] - 2020-11-02
+
+-   Fixed: The following frontend bugs didn't make it to 1.8.1 due to a release mistake
+-   Fixed: Logout did not clear cookies. [issue-810](https://github.com/caprover/caprover/issues/810)
+-   Fixed: Creating a new app while another app is building breaks the UI [Issue-56](https://github.com/caprover/caprover-frontend/
+
 ## [1.8.1] - 2020-10-31
 
 -   New: CapRover now supports ARM processors [issue-445](https://github.com/caprover/caprover/issues/445)

--- a/dockerfile-captain.release
+++ b/dockerfile-captain.release
@@ -15,7 +15,7 @@ RUN npm install --production && \
 
 # Build frontend code using a fixed hash commit. 
 
-ENV FRONTEND_COMMIT_HASH e95fc5b8ee11d15da9017c5ef47ddb75956cf2a6
+ENV FRONTEND_COMMIT_HASH 3d5623f1d6b15a1426a3c995605b5e78e852e79b
 
 RUN mkdir -p /usr/src/app-frontend && cd /usr/src/app-frontend && \
     git clone https://github.com/githubsaturn/caprover-frontend.git && \

--- a/src/utils/CaptainConstants.ts
+++ b/src/utils/CaptainConstants.ts
@@ -17,7 +17,7 @@ const CONSTANT_FILE_OVERRIDE_USER =
 const configs = {
     publishedNameOnDockerHub: 'caprover/caprover',
 
-    version: '1.8.1',
+    version: '1.8.2',
 
     defaultMaxLogSize: '512m',
 


### PR DESCRIPTION
## [1.8.2] - 2020-11-02

-   Fixed: The following frontend bugs didn't make it to 1.8.1 due to a release mistake
-   Fixed: Logout did not clear cookies. [issue-810](https://github.com/caprover/caprover/issues/810)
-   Fixed: Creating a new app while another app is building breaks the UI [Issue-56](https://github.com/caprover/caprover-frontend/
