### PR TITLE
Set the CAPROVER_GIT_COMMIT_SHA env var automatically when building

### DIFF
--- a/src/user/ServiceManager.ts
+++ b/src/user/ServiceManager.ts
@@ -166,12 +166,29 @@ class ServiceManager {
                     .getAppsDataStore()
                     .getAppDefinition(appName)
                     .then(function (app) {
+                        const envVars = app.envVars
+
+                        const includesGitCommitEnvVar = envVars.find(
+                            (envVar) => envVar.key === 'CAPROVER_GIT_COMMIT_SHA'
+                        )
+                        const gitHash =
+                            source.captainDefinitionContentSource?.gitHash ||
+                            source.uploadedTarPathSource?.gitHash
+                        if (gitHash && !includesGitCommitEnvVar) {
+                            if (gitHash) {
+                                envVars.push({
+                                    key: 'CAPROVER_GIT_COMMIT_SHA',
+                                    value: gitHash,
+                                })
+                            }
+                        }
+
                         return self.imageMaker.ensureImage(
                             source,
                             appName,
                             app.captainDefinitionRelativeFilePath,
                             appVersion,
-                            app.envVars
+                            envVars
                         )
                     })
             })


### PR DESCRIPTION
Set the CAPROVER_GIT_COMMIT_SHA env var automatically when building

When we are able to and the environment variable isn't already in use, we set the CAPROVER_GIT_COMMIT_SHA env var to the git has that is being deployed. This allows it to be used when building the image and can be copied into the image to use a runtime as well.

### Tests performed

- [x] Ran the changes locally
- [x] Created [a very simple node project](https://github.com/matt-oakes/node-git-sha-example) which uses this environment variable at build-time and run-time.

Closes #922