### PR TITLE
Custom username for SSH git deployment

### DIFF
--- a/tests/GitHelper.test.ts
+++ b/tests/GitHelper.test.ts
@@ -29,7 +29,7 @@ test('Testing  - sanitizeRepoPathSsh - port', () => {
         GitHelper.sanitizeRepoPathSsh(
             ' git@github.com:username/repository.git/  '
         ).port
-    ).toBe('22')
+    ).toBe(22)
 })
 
 test('Testing  - sanitizeRepoPathSsh - custom port', () => {
@@ -37,7 +37,7 @@ test('Testing  - sanitizeRepoPathSsh - custom port', () => {
         GitHelper.sanitizeRepoPathSsh(
             ' git@github.com:1234/username/repository.git/  '
         ).port
-    ).toBe('1234')
+    ).toBe(1234)
 })
 
 test('Testing  - sanitizeRepoPathSsh from HTTPS', () => {
@@ -46,6 +46,22 @@ test('Testing  - sanitizeRepoPathSsh from HTTPS', () => {
             '  https://github.com/username/repository.git/ '
         ).repoPath
     ).toBe('ssh://git@github.com:22/username/repository.git')
+})
+
+test('Testing  - sanitizeRepoPathSsh - alt domain', () => {
+    expect(
+        GitHelper.sanitizeRepoPathSsh(
+            '  https://gitea@git.alt-domain.com:2221/username/repository/ '
+        ).repoPath
+    ).toBe('ssh://gitea@git.alt-domain.com:2221/username/repository.git')
+})
+
+test('Testing  - sanitizeRepoPathSsh - no owner', () => {
+    expect(
+        GitHelper.sanitizeRepoPathSsh(
+            '  foo@git.alt-domain.com:repository.git '
+        ).repoPath
+    ).toBe('ssh://foo@git.alt-domain.com:22/repository.git')
 })
 
 test('Testing  - getDomainFromSanitizedSshRepoPath - pure', () => {
@@ -74,4 +90,12 @@ test('Testing  - getDomainFromSanitizedSshRepoPath from HTTPS', () => {
             ).repoPath
         )
     ).toBe('github.com')
+})
+
+test('Testing  - getDomainFromSanitizedSshRepoPath - alt domain', () => {
+    expect(
+        GitHelper.getDomainFromSanitizedSshRepoPath(
+            ' ssh://user@some.do-main.com/owner/repository.git/ '
+        )
+    ).toBe('some.do-main.com')
 })

--- a/tests/GitHelper.test.ts
+++ b/tests/GitHelper.test.ts
@@ -48,20 +48,48 @@ test('Testing  - sanitizeRepoPathSsh from HTTPS', () => {
     ).toBe('ssh://git@github.com:22/username/repository.git')
 })
 
+test('Testing  - sanitizeRepoPathSsh - not git suffix', () => {
+    expect(
+        GitHelper.sanitizeRepoPathSsh('  github.com/owner/repository ').repoPath
+    ).toBe('ssh://git@github.com:22/owner/repository.git')
+})
+
 test('Testing  - sanitizeRepoPathSsh - alt domain', () => {
     expect(
         GitHelper.sanitizeRepoPathSsh(
-            '  https://gitea@git.alt-domain.com:2221/username/repository/ '
+            '  git@git.alt-domain.com/owner/repository.git/ '
         ).repoPath
-    ).toBe('ssh://gitea@git.alt-domain.com:2221/username/repository.git')
+    ).toBe('ssh://git@git.alt-domain.com:22/owner/repository.git')
+})
+
+test('Testing  - sanitizeRepoPathSsh - alt user', () => {
+    expect(
+        GitHelper.sanitizeRepoPathSsh(
+            '  foobar@github.com/owner/repository.git/ '
+        ).repoPath
+    ).toBe('ssh://foobar@github.com:22/owner/repository.git')
+})
+
+test('Testing  - sanitizeRepoPathSsh - default user', () => {
+    expect(
+        GitHelper.sanitizeRepoPathSsh('  github.com/owner/repository.git/ ')
+            .repoPath
+    ).toBe('ssh://git@github.com:22/owner/repository.git')
 })
 
 test('Testing  - sanitizeRepoPathSsh - no owner', () => {
     expect(
+        GitHelper.sanitizeRepoPathSsh('  git@github.com:repository.git/ ')
+            .repoPath
+    ).toBe('ssh://git@github.com:22/repository.git')
+})
+
+test('Testing  - sanitizeRepoPathSsh - invalid url', () => {
+    expect(() =>
         GitHelper.sanitizeRepoPathSsh(
-            '  foo@git.alt-domain.com:repository.git '
-        ).repoPath
-    ).toBe('ssh://foo@git.alt-domain.com:22/repository.git')
+            '  git:password@github.com/owner/repository.git/ '
+        )
+    ).toThrow(Error)
 })
 
 test('Testing  - getDomainFromSanitizedSshRepoPath - pure', () => {
@@ -95,7 +123,7 @@ test('Testing  - getDomainFromSanitizedSshRepoPath from HTTPS', () => {
 test('Testing  - getDomainFromSanitizedSshRepoPath - alt domain', () => {
     expect(
         GitHelper.getDomainFromSanitizedSshRepoPath(
-            ' ssh://user@some.do-main.com/owner/repository.git/ '
+            ' ssh://user@some.other-domain.com/owner/repository.git/ '
         )
-    ).toBe('some.do-main.com')
+    ).toBe('some.other-domain.com')
 })


### PR DESCRIPTION
**Problem**
GIT deployment via SSH throws an authorization error if the SSH username is different from 'git'. This happens because the ssh username is hard coded and not taken from the URL

**Fix**
Changed the implementation of the URL sanitizer to take the SSH username from the URL.

**Implementation**
Sanitizing is done in two steps: 1. extract the individual parts from the input URL via a regex (domain, port, repo, ...). 2. construct a new URL by putting the parts together. For the input URL only the domain name and repo name needs to be provided. All other parts of the URL are optional. Default SSH username is 'git' and default port is '22'. '.git' suffix is optional as well.
