### PR TITLE
FR: add build override options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "caprover",
             "version": "0.0.0",
             "dependencies": {
                 "@types/bcryptjs": "^2.4.2",

--- a/src/docker/DockerApi.ts
+++ b/src/docker/DockerApi.ts
@@ -244,7 +244,7 @@ class DockerApi {
         buildLogs: BuildLog,
         envVars: IAppEnvVar[],
         registryConfig: DockerRegistryConfig,
-        overrideOptions: String[]
+        overrideOptions: string[] | undefined
     ) {
         const self = this
 
@@ -269,7 +269,7 @@ class DockerApi {
                 const optionsForBuild: Dockerode.ImageBuildOptions = {
                     t: imageName,
                     buildargs: buildargs,
-                    overrideOptions: [...overrideOptions],
+                    ...overrideOptions,
                 }
 
                 if (Object.keys(registryConfig).length > 0) {

--- a/src/docker/DockerApi.ts
+++ b/src/docker/DockerApi.ts
@@ -243,7 +243,8 @@ class DockerApi {
         tarballFilePath: string,
         buildLogs: BuildLog,
         envVars: IAppEnvVar[],
-        registryConfig: DockerRegistryConfig
+        registryConfig: DockerRegistryConfig,
+        overrideOptions: String[]
     ) {
         const self = this
 
@@ -268,6 +269,7 @@ class DockerApi {
                 const optionsForBuild: Dockerode.ImageBuildOptions = {
                     t: imageName,
                     buildargs: buildargs,
+                    overrideOptions: [...overrideOptions],
                 }
 
                 if (Object.keys(registryConfig).length > 0) {

--- a/src/models/AppDefinition.ts
+++ b/src/models/AppDefinition.ts
@@ -92,6 +92,7 @@ interface IAppDef extends IAppDefinitionBase {
     httpAuth?: IHttpAuth
     appName?: string
     isAppBuilding?: boolean
+    overrideOptions?: string[]
 }
 
 interface IAppDefSaved extends IAppDefinitionBase {

--- a/src/user/ImageMaker.ts
+++ b/src/user/ImageMaker.ts
@@ -92,7 +92,8 @@ export default class ImageMaker {
         appName: string,
         captainDefinitionRelativeFilePath: string,
         appVersion: number,
-        envVars: IAppEnvVar[]
+        envVars: IAppEnvVar[],
+        overrideOptions: string[]
     ): Promise<IBuiltImage> {
         const self = this
 
@@ -183,7 +184,8 @@ export default class ImageMaker {
                             baseImageNameWithoutVerAndReg,
                             appName,
                             appVersion,
-                            envVars
+                            envVars,
+                            overrideOptions
                         )
                     })
             })
@@ -245,7 +247,8 @@ export default class ImageMaker {
         baseImageNameWithoutVersionAndReg: string,
         appName: string,
         appVersion: number,
-        envVars: IAppEnvVar[]
+        envVars: IAppEnvVar[],
+        overrideOptions?: string[]
     ) {
         const self = this
         return Promise.resolve() //
@@ -272,7 +275,8 @@ export default class ImageMaker {
                                 tarFilePath,
                                 self.buildLogsManager.getAppBuildLogs(appName),
                                 envVars,
-                                registryConfig
+                                registryConfig,
+                                overrideOptions
                             )
                             .catch(function (error: AnyError) {
                                 throw ApiStatusCodes.createError(

--- a/src/user/ServiceManager.ts
+++ b/src/user/ServiceManager.ts
@@ -168,13 +168,15 @@ class ServiceManager {
                     .getAppDefinition(appName)
                     .then(function (app) {
                         const envVars = app.envVars || []
+                        const overrideOptions = app.overrideOptions || []
 
                         return self.imageMaker.ensureImage(
                             source,
                             appName,
                             app.captainDefinitionRelativeFilePath,
                             appVersion,
-                            envVars
+                            envVars,
+                            overrideOptions
                         )
                     })
             })

--- a/src/utils/CaptainConstants.ts
+++ b/src/utils/CaptainConstants.ts
@@ -46,6 +46,8 @@ const configs = {
     defaultEmail: 'runner@caprover.com',
 
     captainSubDomain: 'captain',
+
+    overrideOptions: [],
 }
 
 const data = {


### PR DESCRIPTION
**This isn't complete but I wanted to make sure I am going down the right path.** 
I brought up in an old issue, I'd like to know more about the implications of making this change. 

I believe caprover uses /var/run/docker.sock to spawn build containers, with this change to the server a user should be able to add extra build option flags to be passed to the docker build command.  

[https://github.com/caprover/caprover/blob/master/CONTRIBUTING.md](url)

TODO:
- [ ] Discuss with the caprover team I haven't spoken on the slack group yet.
- [ ] Update the docs
- [ ] Test functionality
- [ ] Make sure I'm not breaking anything since this is my first commit to the project and I'm not 100% familiar with the codebase.

