### PR TITLE
fix: provide configured captainSubDomain to frontend

### DIFF
--- a/src/routes/user/apps/appdefinition/AppDefinitionRouter.ts
+++ b/src/routes/user/apps/appdefinition/AppDefinitionRouter.ts
@@ -94,6 +94,7 @@ router.get('/', function (req, res, next) {
             baseApi.data = {
                 appDefinitions: appsArray,
                 rootDomain: dataStore.getRootDomain(),
+                captainSubDomain: CaptainConstants.configs.captainSubDomain,
                 defaultNginxConfig: defaultNginxConfig,
             }
 

--- a/src/routes/user/system/SystemRouter.ts
+++ b/src/routes/user/system/SystemRouter.ts
@@ -133,6 +133,7 @@ router.get('/info/', function (req, res, next) {
                 rootDomain: dataStore.hasCustomDomain()
                     ? dataStore.getRootDomain()
                     : '',
+                captainSubDomain: CaptainConstants.configs.captainSubDomain,
             }
         })
         .then(function (data) {


### PR DESCRIPTION
https://github.com/caprover/caprover/commit/7f16a7099bb4c4aac995e5c4ea1470cc53b5a201 introduced a configurable captain sub domain, but the subdomain is still hard-coded in the frontend, which leads to e.g. broken webhook URLs: https://github.com/caprover/caprover-frontend/blob/38ac97e0bd9662ef82ebef8f4b01bc57f44f3dc7/src/containers/apps/appDetails/deploy/Deployment.tsx#L130

This PR makes the API provide the configured `captainSubDomain` to the frontend and is the basis for the related caprover-frontend PR (https://github.com/caprover/caprover-frontend/pull/96) that makes the frontend consume `captainSubDomain` so it uses the correct URLs :)