### PR TITLE
Nginx container supports custom ports

### DIFF
--- a/src/user/system/LoadBalancerManager.ts
+++ b/src/user/system/LoadBalancerManager.ts
@@ -572,7 +572,7 @@ class LoadBalancerManager {
                             protocol: 'tcp',
                             publishMode: 'host',
                             containerPort: 443,
-                            hostPort: 443,
+                            hostPort: CaptainConstants.nginxHttpsPort,
                         },
                     ],
                     nodeId,

--- a/src/utils/CaptainConstants.ts
+++ b/src/utils/CaptainConstants.ts
@@ -17,7 +17,9 @@ const CONSTANT_FILE_OVERRIDE_USER =
 const configs = {
     publishedNameOnDockerHub: EnvVars.CAPTAIN_IMAGE_NAME,
 
-    version: EnvVars.CAPTAIN_IMAGE_VERSION?EnvVars.CAPTAIN_IMAGE_VERSION:'1.10.2',
+    version: EnvVars.CAPTAIN_IMAGE_VERSION
+        ? EnvVars.CAPTAIN_IMAGE_VERSION
+        : '1.10.2',
 
     defaultMaxLogSize: '512m',
 

--- a/src/utils/CaptainConstants.ts
+++ b/src/utils/CaptainConstants.ts
@@ -15,9 +15,9 @@ const CONSTANT_FILE_OVERRIDE_USER =
     CAPTAIN_DATA_DIRECTORY + '/config-override.json'
 
 const configs = {
-    publishedNameOnDockerHub: 'caprover/caprover',
+    publishedNameOnDockerHub: EnvVars.CAPTAIN_IMAGE_NAME,
 
-    version: '1.10.1',
+    version: EnvVars.CAPTAIN_IMAGE_VERSION,
 
     defaultMaxLogSize: '512m',
 
@@ -145,7 +145,9 @@ const data = {
 
     // ********************* HTTP Related Constants  ************************
 
-    nginxPortNumber: 80,
+    nginxPortNumber: EnvVars.NGINX_HTTP_PORT,
+
+    nginxHttpsPort: EnvVars.NGINX_HTTPS_PORT,
 
     netDataRelativePath: '/net-data-monitor',
 

--- a/src/utils/CaptainConstants.ts
+++ b/src/utils/CaptainConstants.ts
@@ -17,7 +17,7 @@ const CONSTANT_FILE_OVERRIDE_USER =
 const configs = {
     publishedNameOnDockerHub: EnvVars.CAPTAIN_IMAGE_NAME,
 
-    version: EnvVars.CAPTAIN_IMAGE_VERSION,
+    version: EnvVars.CAPTAIN_IMAGE_VERSION?EnvVars.CAPTAIN_IMAGE_VERSION:'1.10.2',
 
     defaultMaxLogSize: '512m',
 

--- a/src/utils/CaptainInstaller.ts
+++ b/src/utils/CaptainInstaller.ts
@@ -347,6 +347,14 @@ export function install() {
                     hostPort: 38000,
                 })
             }
+            env.push({
+                key: EnvVar.keys.NGINX_HTTP_PORT,
+                value: EnvVar.NGINX_HTTP_PORT+'',
+            })
+            env.push({
+                key: EnvVar.keys.NGINX_HTTPS_PORT,
+                value: EnvVar.NGINX_HTTPS_PORT+'',
+            })
 
             ports.push({
                 protocol: 'tcp',

--- a/src/utils/CaptainInstaller.ts
+++ b/src/utils/CaptainInstaller.ts
@@ -349,11 +349,11 @@ export function install() {
             }
             env.push({
                 key: EnvVar.keys.NGINX_HTTP_PORT,
-                value: EnvVar.NGINX_HTTP_PORT+'',
+                value: EnvVar.NGINX_HTTP_PORT + '',
             })
             env.push({
                 key: EnvVar.keys.NGINX_HTTPS_PORT,
-                value: EnvVar.NGINX_HTTPS_PORT+'',
+                value: EnvVar.NGINX_HTTPS_PORT + '',
             })
 
             ports.push({

--- a/src/utils/EnvVars.ts
+++ b/src/utils/EnvVars.ts
@@ -23,11 +23,19 @@ export default {
 
     DEFAULT_PASSWORD: process.env.DEFAULT_PASSWORD,
 
-    NGINX_HTTP_PORT: parseInt(process.env.NGINX_HTTP_PORT?process.env.NGINX_HTTP_PORT:'80'),
+    NGINX_HTTP_PORT: parseInt(
+        process.env.NGINX_HTTP_PORT ? process.env.NGINX_HTTP_PORT : '80'
+    ),
 
-    NGINX_HTTPS_PORT: parseInt(process.env.NGINX_HTTPS_PORT?process.env.NGINX_HTTPS_PORT:'443'),
+    NGINX_HTTPS_PORT: parseInt(
+        process.env.NGINX_HTTPS_PORT ? process.env.NGINX_HTTPS_PORT : '443'
+    ),
 
-    CAPTAIN_IMAGE_NAME: process.env.CAPTAIN_IMAGE_NAME?process.env.CAPTAIN_IMAGE_NAME:'caprover/caprover',
+    CAPTAIN_IMAGE_NAME: process.env.CAPTAIN_IMAGE_NAME
+        ? process.env.CAPTAIN_IMAGE_NAME
+        : 'caprover/caprover',
 
-    CAPTAIN_IMAGE_VERSION: process.env.CAPTAIN_IMAGE_VERSION?process.env.CAPTAIN_IMAGE_VERSION:'latest',
+    CAPTAIN_IMAGE_VERSION: process.env.CAPTAIN_IMAGE_VERSION
+        ? process.env.CAPTAIN_IMAGE_VERSION
+        : 'latest',
 }

--- a/src/utils/EnvVars.ts
+++ b/src/utils/EnvVars.ts
@@ -5,6 +5,8 @@ export default {
         DEFAULT_PASSWORD: 'DEFAULT_PASSWORD',
         IS_CAPTAIN_INSTANCE: 'IS_CAPTAIN_INSTANCE',
         DEMO_MODE_ADMIN_IP: 'DEMO_MODE_ADMIN_IP',
+        NGINX_HTTP_PORT: 'NGINX_HTTP_PORT',
+        NGINX_HTTPS_PORT: 'NGINX_HTTPS_PORT',
     },
 
     BY_PASS_PROXY_CHECK: process.env.BY_PASS_PROXY_CHECK,
@@ -20,4 +22,12 @@ export default {
     DEMO_MODE_ADMIN_IP: process.env.DEMO_MODE_ADMIN_IP,
 
     DEFAULT_PASSWORD: process.env.DEFAULT_PASSWORD,
+
+    NGINX_HTTP_PORT: parseInt(process.env.NGINX_HTTP_PORT?process.env.NGINX_HTTP_PORT:'80'),
+
+    NGINX_HTTPS_PORT: parseInt(process.env.NGINX_HTTPS_PORT?process.env.NGINX_HTTPS_PORT:'443'),
+
+    CAPTAIN_IMAGE_NAME: process.env.CAPTAIN_IMAGE_NAME?process.env.CAPTAIN_IMAGE_NAME:'caprover/caprover',
+
+    CAPTAIN_IMAGE_VERSION: process.env.CAPTAIN_IMAGE_VERSION?process.env.CAPTAIN_IMAGE_VERSION:'latest',
 }

--- a/src/utils/EnvVars.ts
+++ b/src/utils/EnvVars.ts
@@ -35,7 +35,5 @@ export default {
         ? process.env.CAPTAIN_IMAGE_NAME
         : 'caprover/caprover',
 
-    CAPTAIN_IMAGE_VERSION: process.env.CAPTAIN_IMAGE_VERSION
-        ? process.env.CAPTAIN_IMAGE_VERSION
-        : 'latest',
+    CAPTAIN_IMAGE_VERSION: process.env.CAPTAIN_IMAGE_VERSION,
 }


### PR DESCRIPTION
Added support for custom ports of nginx containers, setting new ports through the following environment variables:
-e NGINX_HTTP_PORT="80"
-e NGINX_HTTPS_PORT="443"
