### PR TITLE
Throw error with status code on empty namespace

### DIFF
--- a/src/datastore/DataStoreProvider.ts
+++ b/src/datastore/DataStoreProvider.ts
@@ -11,7 +11,10 @@ const dataStoreCache: IHashMapGeneric<DataStore> = {}
 export default {
     getDataStore: function (namespace: string) {
         if (!namespace) {
-            throw new Error('NameSpace is empty')
+            throw ApiStatusCodes.createError(
+                ApiStatusCodes.STATUS_ERROR_NOT_AUTHORIZED,
+                'Empty namespace'
+            )
         }
 
         if (namespace !== CaptainConstants.rootNameSpace) {


### PR DESCRIPTION
Close [#1411](https://github.com/caprover/caprover/issues/1411)

When throwing an error without status code it resolve in a 500 error.
Using an error with a status code resolve in more explicit errors.
