### PR TITLE
chore: upgrade caprover/netdata docker image to the latest version

### DIFF
--- a/src/utils/CaptainConstants.ts
+++ b/src/utils/CaptainConstants.ts
@@ -35,7 +35,7 @@ const configs = {
 
     dockerApiVersion: 'v1.40',
 
-    netDataImageName: 'caprover/netdata:v1.8.0',
+    netDataImageName: 'caprover/netdata:v1.34.1',
 
     registryImageName: 'registry:2',
 


### PR DESCRIPTION
caprover/netdata docker image was upgraded last night (https://github.com/caprover/netdata-docker/pull/3).
Let's bump its version in caprover.
