### PR TITLE
Trim the customdomain before adding it

### DIFF
--- a/src/routes/user/apps/appdefinition/AppDefinitionRouter.ts
+++ b/src/routes/user/apps/appdefinition/AppDefinitionRouter.ts
@@ -126,7 +126,7 @@ router.post('/customdomain/', function (req, res, next) {
         InjectionExtractor.extractUserFromInjected(res).user.serviceManager
 
     const appName = req.body.appName
-    const customDomain = (req.body.customDomain || '').toLowerCase()
+    const customDomain = (req.body.customDomain || '').toLowerCase().trim()
 
     // verify customdomain.com going through the default NGINX
     // Add customdomain.com to app in Data Store


### PR DESCRIPTION
Domains are frequently copied and pasted and the input may therefore end with spaces or tabs. This PR removes them as the user intended to add the domain without spaces.
