### PR TITLE
Changed clone commands to use ---recurse-submodules

### DIFF
--- a/src/utils/GitHelper.ts
+++ b/src/utils/GitHelper.ts
@@ -79,7 +79,7 @@ export default class GitHelper {
                         .env('GIT_SSH_COMMAND', `ssh -i ${SSH_KEY_PATH}`) //
                         .raw([
                             'clone',
-                            '--recursive',
+                            '--recurse-submodules',
                             '-b',
                             branch,
                             REPO_GIT_PATH,
@@ -100,7 +100,7 @@ export default class GitHelper {
             Logger.dev(`Cloning HTTPS ${remote}`)
             return git() //
                 .silent(true) //
-                .raw(['clone', '--recursive', '-b', branch, remote, directory])
+                .raw(['clone', '--recurse-submodules', '-b', branch, remote, directory])
                 .then(function () {
                     //
                 })


### PR DESCRIPTION
Fix proposed by @githubsaturn on issue #1520.

According to [git docs](https://git-scm.com/book/en/v2/Git-Tools-Submodules) on submodules the clone flag `--recurse-submodules` should automatically make sure to initialize and update any submodule or nested submodule if any of the submodules in the repository have submodules themselves.