### PR TITLE
test: only run backup tests in CI

### DIFF
--- a/tests/backup.test.ts
+++ b/tests/backup.test.ts
@@ -29,64 +29,75 @@ afterEach(() => {
     return cleanup()
 })
 
-test('No backup file', () => {
-    const bk = new BackupManager()
-    return Promise.resolve()
-        .then(function () {
-            return bk.checkAndPrepareRestoration()
-        })
-        .then(function (data) {
-            expect(data).toBeFalsy()
-        })
-})
+if (process.env.CI) {
+    describe('backup tests [CI only]', backupTests)
+} else {
+    describe.skip('backup tests [CI only]', backupTests)
+}
 
-test('Test backup file', () => {
-    const bk = new BackupManager()
-    return Promise.resolve()
-        .then(function () {
-            return copy(`${__dirname}/backup.tar`, BACKUP_FILE_PATH_ABSOLUTE)
-        })
-        .then(function () {
-            return bk.checkAndPrepareRestoration()
-        })
-        .then(function () {
-            return readJson(
-                CaptainConstants.restoreDirectoryPath +
-                    '/restore-instructions.json'
-            )
-        })
-        .then(function (ret: RestoringInfo) {
-            const expectedValue = {
-                nodesMapping: [
-                    {
-                        newIp: 'CURRENT_NODE_DONT_CHANGE',
-                        oldIp: '123.123.123.123',
-                        privateKeyPath: '',
-                        user: '',
-                    },
-                ],
-                oldNodesForReference: [
-                    {
-                        nodeData: {
-                            nodeId: '123456789',
-                            type: 'manager',
-                            isLeader: true,
-                            hostname: 'test',
-                            architecture: 'x86_64',
-                            operatingSystem: 'linux',
-                            nanoCpu: 8000000000,
-                            memoryBytes: 8241434624,
-                            dockerEngineVersion: '18.09.2',
-                            ip: '123.123.123.123',
-                            state: 'ready',
-                            status: 'active',
+function backupTests() {
+    test('No backup file', () => {
+        const bk = new BackupManager()
+        return Promise.resolve()
+            .then(function () {
+                return bk.checkAndPrepareRestoration()
+            })
+            .then(function (data) {
+                expect(data).toBeFalsy()
+            })
+    })
+
+    test('Test backup file', () => {
+        const bk = new BackupManager()
+        return Promise.resolve()
+            .then(function () {
+                return copy(
+                    `${__dirname}/backup.tar`,
+                    BACKUP_FILE_PATH_ABSOLUTE
+                )
+            })
+            .then(function () {
+                return bk.checkAndPrepareRestoration()
+            })
+            .then(function () {
+                return readJson(
+                    CaptainConstants.restoreDirectoryPath +
+                        '/restore-instructions.json'
+                )
+            })
+            .then(function (ret: RestoringInfo) {
+                const expectedValue = {
+                    nodesMapping: [
+                        {
+                            newIp: 'CURRENT_NODE_DONT_CHANGE',
+                            oldIp: '123.123.123.123',
+                            privateKeyPath: '',
+                            user: '',
                         },
-                        appsLockOnThisNode: ['pers1'],
-                    },
-                ],
-            }
-            expect(isDeepStrictEqual(ret, expectedValue)).toBe(true)
-            ret.nodesMapping[0].oldIp += ' '
-            expect(isDeepStrictEqual(ret, expectedValue)).toBe(false)
-        })
-})
+                    ],
+                    oldNodesForReference: [
+                        {
+                            nodeData: {
+                                nodeId: '123456789',
+                                type: 'manager',
+                                isLeader: true,
+                                hostname: 'test',
+                                architecture: 'x86_64',
+                                operatingSystem: 'linux',
+                                nanoCpu: 8000000000,
+                                memoryBytes: 8241434624,
+                                dockerEngineVersion: '18.09.2',
+                                ip: '123.123.123.123',
+                                state: 'ready',
+                                status: 'active',
+                            },
+                            appsLockOnThisNode: ['pers1'],
+                        },
+                    ],
+                }
+                expect(isDeepStrictEqual(ret, expectedValue)).toBe(true)
+                ret.nodesMapping[0].oldIp += ' '
+                expect(isDeepStrictEqual(ret, expectedValue)).toBe(false)
+            })
+    })
+}


### PR DESCRIPTION
As per https://github.com/caprover/caprover/pull/1553#issuecomment-1304282521

(need to hit <a href="https://github.com/caprover/caprover/pull/1555/files?w=1"><img align="center" src="https://user-images.githubusercontent.com/30421456/200122064-30e2e65c-6d3d-4eef-96cd-cd102e92a7b6.png"></a> "Hide Whitespace Changes" to make the diff readable)
