### PR TITLE
Documentation/docker improve macos documentation and add Catalina and above native support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ First, you need a Captain instance running in debug mode, this can be a remote s
 or your local machine itself. Needless to say, Docker is required (same minimum version as mentioned in README). Ubuntu is the best dev environment for CapRover.
 
 > Docker for Mac users: You need to add `/captain` to shared paths.  
-> To do so, click on the Docker icon -> Preferences -> File Sharing and add `/captain`
+> To do so, click on the Docker icon -> Preferences -> Ressources -> File Sharing and add `/captain`
 > This is not possible in Catalina or above versions. You can try your luck by changing `CAPTAIN_BASE_DIRECTORY` in `src/utils/CaptainConstants.ts` and in `dev-scripts/dev-clean-run-as-dev.sh` but it might be best to develop in a linux VM for best results.
 
 Log in to your machine, clone the git repo and run the following lines:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,22 +27,43 @@ The goal is to make the common use-cases exposed via simple controls on UI while
 First, you need a Captain instance running in debug mode, this can be a remote server, a VM on your local machine,
 or your local machine itself. Needless to say, Docker is required (same minimum version as mentioned in README). Ubuntu is the best dev environment for CapRover.
 
-> Docker for Mac users: You need to add `/captain` to shared paths.  
-> To do so, click on the Docker icon -> Preferences -> Ressources -> File Sharing and add `/captain`
-> This is not possible in Catalina or above versions. You can try your luck by changing `CAPTAIN_BASE_DIRECTORY` in `src/utils/CaptainConstants.ts` and in `dev-scripts/dev-clean-run-as-dev.sh` but it might be best to develop in a linux VM for best results.
-
 Log in to your machine, clone the git repo and run the following lines:
-
+#### On Linux and Windows
 ```bash
 $   npm install
 $   npm run build
-$   ./dev-scripts/dev-clean-run-as-dev.sh
+$   sudo ./dev-scripts/dev-clean-run-as-dev.sh
 ```
 
 You are good to go! You can run the following line to see the logs for the back-end service.
 
 ```bash
 npm run dev
+```
+
+#### On macOs
+##### Prepare your system (for Catalina and above)
+Because of security restriction we have more step to apply on macOs.
+Create a folder wherever you want (for me it will be /opt/captain).
+Link this folder to the root folder (Apple does not allow to create folder on the root but you can do it with a symb link by adding the file in `/etc/synthetic.conf` [see](https://stackoverflow.com/questions/58396821/what-is-the-proper-way-to-create-a-root-sym-link-in-catalina))
+(don't panic id the file does not exist, if you create it will work well.)
+1) `sudo vi /etc/synthetic.conf`
+2) add `captain opt/captain` into this file (note this is a tab and not a space ((Ctrl-V + Tab) character))
+3) reboot
+4) Prepare your docker system
+
+##### Prepare your docker (for all macOs User)
+
+> You need to add `/captain` to shared paths.  
+> To do so, click on the Docker icon -> Preferences -> Ressources -> File Sharing and add `/captain`
+
+##### 
+use node 14 then
+```bash
+$   npm install
+$   npm run build
+$   sudo ./dev-scripts/dev-clean-run-as-dev-macos-step-1.sh
+$   ./dev-scripts/dev-clean-run-as-dev-macos-step-2.sh
 ```
 
 The main differences between the release and debug mode are:

--- a/dev-scripts/dev-clean-run-as-dev-macos-step-1.sh
+++ b/dev-scripts/dev-clean-run-as-dev-macos-step-1.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if ! [ $(id -u) = 0 ]; then
+   echo "Must run as sudo or root"
+   exit 1
+fi
+
+# on macos Catalina and above, /captain is a symb link. we cannot remove the folder so we delete all files inside
+# rm -rf /captain && mkdir /captain
+rm -rf /captain/*
+chmod -R 777 /captain/

--- a/dev-scripts/dev-clean-run-as-dev-macos-step-2.sh
+++ b/dev-scripts/dev-clean-run-as-dev-macos-step-2.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+if ! [ $(id -u) <> 0 ]; then
+   echo "Must not be run as sudo or root on macos (macos security) please run the step 1 as root and this step as standard user"
+   exit 1
+fi
+
+docker service rm $(docker service ls -q)
+sleep 1
+docker secret rm captain-salt
+docker build -t captain-debug -f dockerfile-captain.debug .
+docker run \
+   -e "CAPTAIN_IS_DEBUG=1" \
+   -e "MAIN_NODE_IP_ADDRESS=127.0.0.1" \
+   -v /var/run/docker.sock:/var/run/docker.sock \
+   -v /captain:/captain \
+   -v $(pwd):/usr/src/app captain-debug
+sleep 2s
+docker service logs captain-captain --follow


### PR DESCRIPTION
Hi,

I'm currently working on the frontend but cannot run the backend because I'm using a Monteray version of macOs.
I create the script (copy paste and adapted from the linux one) for specific mac command and security enforcement and document each specific steps in the contributing guide.
I would happy to take any reviews comments.
<img width="1268" alt="Capture d’écran 2022-12-15 à 11 43 50" src="https://user-images.githubusercontent.com/39310468/207841593-0408c856-9f7c-4f2c-a3d6-a49a4ea58412.png">
<img width="1504" alt="Capture d’écran 2022-12-15 à 11 43 27" src="https://user-images.githubusercontent.com/39310468/207841598-ecdd80f9-bd3f-4a1a-ab12-cb25ea5ba99b.png">

