### PR TITLE
Fix app config update for global mode services

### DIFF
--- a/src/docker/DockerApi.ts
+++ b/src/docker/DockerApi.ts
@@ -1479,12 +1479,10 @@ class DockerApi {
                     (instanceCount && instanceCount > 0) ||
                     instanceCount === 0
                 ) {
-                    if (!updatedData.Mode.Replicated) {
-                        throw new Error(
-                            'Non replicated services cannot be associated with instance count'
-                        )
+                    // assign instance count as replicas for replicated mode services, not for global mode services
+                    if (updatedData.Mode.Replicated) {
+                        updatedData.Mode.Replicated.Replicas = instanceCount
                     }
-                    updatedData.Mode.Replicated.Replicas = instanceCount
                 }
 
                 return Utils.mergeObjects(updatedData, serviceUpdateOverride)


### PR DESCRIPTION
Currently, CapRover v1.10.1 is not able to create services in global mode. A workaround https://github.com/caprover/caprover/issues/1699#issuecomment-1469012497 was suggested to create a global service using Docker CLI, then adding the app in CapRover, but it still doesn't allow for app config updates from the UI due to an 'instance count' validation for non-replicated services.

This PR simplifies the validation limiting it to replicated mode services only, and allowing updates of global mode services to go through.