### PR TITLE
feat: Add Node.js typesccript default template

### DIFF
--- a/dockerfiles/node-typescript
+++ b/dockerfiles/node-typescript
@@ -1,4 +1,4 @@
-# FROM node:18-alpine as builder
+# FROM node:18-alpine
 # Uncomment the line above if you want to use a Dockerfile instead of templateId
 
 
@@ -13,15 +13,15 @@ COPY ./ /usr/src/app
 
 RUN npm run build -- --outDir build
 
-FROM node:18-alpine as run
+FROM node:18-alpine
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-COPY --from=builder /usr/src/app/package*.json /usr/src/app
+COPY --from=0 /usr/src/app/package*.json /usr/src/app
 
 RUN npm install --production && npm cache clean --force
-COPY --from=builder /usr/src/app/build /usr/src/app/build
+COPY --from=0 /usr/src/app/build /usr/src/app/build
 
 ENV NODE_ENV production
 ENV PORT 80

--- a/dockerfiles/node-typescript
+++ b/dockerfiles/node-typescript
@@ -1,0 +1,30 @@
+# FROM node:18-alpine as builder
+# Uncomment the line above if you want to use a Dockerfile instead of templateId
+
+
+RUN apk update && apk upgrade && \
+    apk add --no-cache git
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY ./package*.json /usr/src/app/
+RUN npm install && npm cache clean --force
+COPY ./ /usr/src/app
+
+RUN npm run build -- --outDir build
+
+FROM node:18-alpine as run
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY --from=builder /usr/src/app/package*.json /usr/src/app
+
+RUN npm install --production && npm cache clean --force
+COPY --from=builder /usr/src/app/build /usr/src/app/build
+
+ENV NODE_ENV production
+ENV PORT 80
+EXPOSE 80
+
+CMD [ "npm", "start" ]

--- a/dockerfiles/node-typescript
+++ b/dockerfiles/node-typescript
@@ -18,7 +18,7 @@ FROM node:18-alpine
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-COPY --from=0 /usr/src/app/package*.json /usr/src/app
+COPY --from=0 /usr/src/app/package*.json /usr/src/app/
 
 RUN npm install --production && npm cache clean --force
 COPY --from=0 /usr/src/app/build /usr/src/app/build

--- a/src/user/TemplateHelper.ts
+++ b/src/user/TemplateHelper.ts
@@ -13,6 +13,11 @@ class TemplateHelper {
                 tagSuffix: '-alpine',
             },
             {
+                templateName: 'node-typescript',
+                dockerHubImageName: 'library/node',
+                tagSuffix: '-alpine',
+            },
+            {
                 templateName: 'php',
                 dockerHubImageName: 'library/php',
                 tagSuffix: '-apache',


### PR DESCRIPTION
Adding a new dockerfile template.

I found it useful as typescript is now commonly used for node.js projects

The docker build consists of two stages :

- build stage : run `npm run build` (forcing compilation to `build` folder)
- run stage : run `npm start`

It presumes user define a build stage, the same way we pretend a `npm start` script exists with the node template. Moreover, I override the outDir to ensure compilation to `build` folder, in case the output directory defined in `tsconfig.json` is another name

Just a point : I explicited the node version in the second stage. I didn't found a way to manage it with the existing code. If you have idea or suggestions, to manage this problem, feel free to tell me

I'm opened to feedback and reviews !