### PR TITLE
[WIP] suggestion on how to add custom command for Dockerfile

### DIFF
--- a/src/user/ImageMaker.ts
+++ b/src/user/ImageMaker.ts
@@ -468,9 +468,12 @@ export default class ImageMaker {
                 }
             })
             .then(function (dockerfileContent) {
+                const hasCustomCMD = data.customCMD && data.customCMD.length > 0;
+                const finalDockerFileContent = hasCustomCMD ? dockerfileContent.replace(/CMD.*/g, `CMD ${data.customCMD}`) : dockerfileContent
+
                 return fs.outputFile(
                     `${directoryWithCaptainDefinition}/${DOCKER_FILE}`,
-                    dockerfileContent
+                    finalDockerFileContent
                 )
             })
     }


### PR DESCRIPTION
This is a WIP PR right now to demonstrate a possible solution and keep working on it if it fits team's vision. I think it's better than submitting an issue in this case.

# The Problem 1

Often times a single image is used to run different processes: web, worker, webscokets etc. Sometimes it can be 10+ processes required for app to work. It is possible to solve this issue right now using custom location of `captain-definition` +  `Dockerfile`. However, it requires creating 2 files per each process (so potentially 20+ files to support caprover deployment). Dockerfiles also may be lengthy sometimes. And changing your Dockerfile requires you to change all 20+ caprover-specific Dockerfiles which is error-prone. It is also not feasible to maintain custom Dockerfiles using `dockerfileLines` because it moves Dockerfile maintenance from repository to caprover

# The Problem 2

Even if the problem above is solved using custom `captain-definition` + `Dockerfile` per process, we still need to change Dockerfile each time we want to, say, change some arguments to our `CMD`.

# Potential Workaround

It seems like it should be possible to each custom-CMD-like experience using `dockerfileLines` while using pre-built images, then our command will look like
```Dockerfile
FROM my_image:latest
CMD my_command
```

But it means we leaves us with 3rd-party build system and I'd like Caprover to handle it.

# Proposed Solution

In this PR I suggest to add a simple workaround for deployment with combination of `Dockerfile` + `Custom CMD` while other deployment methods won't be affected. Simply replace CMD string in Dockerfile with one provided in App Definition. It should be straightforward and entire responsibility is on the developer