### PR TITLE
Add support for saving tags when registering apps

### DIFF
--- a/src/datastore/AppsDataStore.ts
+++ b/src/datastore/AppsDataStore.ts
@@ -856,11 +856,23 @@ class AppsDataStore {
     /**
      * Creates a new app definition.
      *
-     * @param appName                   The appName you want to register
-     * @param hasPersistentData         whether the app has persistent data, you can only run one instance of the app.
+     * @param options:
+     * {
+     *   appName                   The appName you want to register
+     *   hasPersistentData         whether the app has persistent data, you can only run one instance of the app.
+     *   tags                      Tags for the app
+     * }
      * @returns {Promise}
      */
-    registerAppDefinition(appName: string, hasPersistentData: boolean) {
+    registerAppDefinition({
+        appName,
+        hasPersistentData,
+        tags = [],
+    }: {
+        appName: string
+        hasPersistentData: boolean
+        tags?: string[]
+    }) {
         const self = this
 
         return new Promise<IAppDef>(function (resolve, reject) {
@@ -894,7 +906,9 @@ class AppsDataStore {
                 envVars: [],
                 volumes: [],
                 ports: [],
-                tags: [],
+                tags: tags.map((tagName) => ({
+                    tagName,
+                })),
                 versions: [],
                 deployedVersion: 0,
                 notExposeAsWebApp: false,

--- a/src/routes/user/apps/appdefinition/AppDefinitionRouter.ts
+++ b/src/routes/user/apps/appdefinition/AppDefinitionRouter.ts
@@ -192,6 +192,8 @@ router.post('/register/', function (req, res, next) {
 
     const appName = req.body.appName as string
     const hasPersistentData = !!req.body.hasPersistentData
+    const tags = req.body.tags
+
     const isDetachedBuild = !!req.query.detached
 
     let appCreated = false
@@ -200,7 +202,11 @@ router.post('/register/', function (req, res, next) {
 
     dataStore
         .getAppsDataStore()
-        .registerAppDefinition(appName, hasPersistentData)
+        .registerAppDefinition({
+            appName,
+            hasPersistentData,
+            tags,
+        })
         .then(function () {
             appCreated = true
         })

--- a/src/utils/MigrateCaptainDuckDuck.ts
+++ b/src/utils/MigrateCaptainDuckDuck.ts
@@ -204,10 +204,10 @@ export default class MigrateCaptainDuckDuck {
 
                     const p = Promise.resolve() //
                         .then(function () {
-                            return appStore.registerAppDefinition(
+                            return appStore.registerAppDefinition({
                                 appName,
-                                !!app.hasPersistentData
-                            )
+                                hasPersistentData: !!app.hasPersistentData,
+                            })
                         })
                         .then(function () {
                             for (


### PR DESCRIPTION
The API changes needed for https://github.com/caprover/caprover-frontend/pull/137

If the tags are not sent from the client, they default to `[]`.