### PR TITLE
Upgrading Docker API Version to 1.43 in order to add cap_add functionality

### DIFF
--- a/src/utils/CaptainConstants.ts
+++ b/src/utils/CaptainConstants.ts
@@ -33,7 +33,7 @@ const configs = {
 
     registrySubDomainPort: 996,
 
-    dockerApiVersion: 'v1.40',
+    dockerApiVersion: 'v1.43',
 
     netDataImageName: 'caprover/netdata:v1.34.1',
 


### PR DESCRIPTION
Upgrading dockerApiVersion to 1.43

-This package upgrade is required to get cap_add functionality with docker swarm