### PR TITLE
add http3 to default template

### DIFF
--- a/template/server-block-conf.ejs
+++ b/template/server-block-conf.ejs
@@ -36,7 +36,11 @@ server {
     }
     if (s.hasSsl) {
     %>
-        listen              443 ssl http2;
+        http2 on;
+        listen 443 ssl;
+        http3 on;
+        listen 443 quic;
+        add_header Alt-Svc 'h3=":443"; ma=86400';
         ssl_certificate     <%-s.crtPath%>;
         ssl_certificate_key <%-s.keyPath%>;
     <%


### PR DESCRIPTION
As discussed here https://github.com/caprover/caprover/pull/1355#issuecomment-2440173108 the http3 is now supported on all modern browser and is available by default in nginx. 
https://caniuse.com/http3
https://github.com/caprover/caprover/pull/1355#issuecomment-2450203036
By updating the nginx to version `>=1.25.0` and merging this PR we can have http3 support by default for all users.

needs this PR:

- [ ] #2183 