### PR TITLE
Change "listen ... http2" directive

### DIFF
--- a/template/server-block-conf.ejs
+++ b/template/server-block-conf.ejs
@@ -36,7 +36,8 @@ server {
     }
     if (s.hasSsl) {
     %>
-        listen              443 ssl http2;
+        listen              443 ssl;
+        http2               on;
         ssl_certificate     <%-s.crtPath%>;
         ssl_certificate_key <%-s.keyPath%>;
     <%


### PR DESCRIPTION
The current version of nginx used gives this warning:

nginx: [warn] the "listen ... http2" directive is deprecated, use the "http2" directive instead

In order to avoid this warning the configuration is updated to the new configuration.