### PR TITLE
Hotfix: Enhance SSH_PATH_RE on GitHelper to improve URL parsing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ The goal is to make the common use-cases exposed via simple controls on UI while
    variables, exposed ports, useful file locations and container parameters.
 2. Make sure your commit comments are self explanatory.
 3. Discuss the changes you want to make beforehand.
-4. Please avoid making opinion-based changes if it's just a code-style change - this includes, but not limited to, changes to how we work with promises, class inheritence and etc.
+4. Please avoid making opinion-based changes if it's just a code-style change - this includes, but not limited to, changes to how we work with promises, class inheritance and etc.
 5. To keep the process simple with just a few contributors, development happens directly on the master branch
    and releases will be deployed on the same branch.
 6. By creating a Pull Request, you agree to all terms in https://github.com/caprover/caprover/blob/master/contrib.md
@@ -60,7 +60,7 @@ Link this folder to the root folder (Apple does not allow to create folder on th
 ##### Prepare your docker (for all macOs User)
 
 > You need to add `/captain` to shared paths.  
-> To do so, click on the Docker icon -> Preferences -> Ressources -> File Sharing and add `/captain`
+> To do so, click on the Docker icon -> Preferences -> Resources -> File Sharing and add `/captain`
 
 #####
 

--- a/src/utils/GitHelper.ts
+++ b/src/utils/GitHelper.ts
@@ -147,8 +147,9 @@ export default class GitHelper {
             repo: found.groups?.repo,
             suffix: found.groups?.suffix ?? '',
             get repoPath() {
-                return `ssh://${this.user}@${this.domain}:${this.port}/${this.owner
-                    }${this.owner && '/'}${this.repo}${this.suffix}`
+                return `ssh://${this.user}@${this.domain}:${this.port}/${
+                    this.owner
+                }${this.owner && '/'}${this.repo}${this.suffix}`
             },
         }
     }

--- a/src/utils/GitHelper.ts
+++ b/src/utils/GitHelper.ts
@@ -15,11 +15,11 @@ export default class GitHelper {
             /^\s*/,
             /(?:(?<proto>[a-z]+):\/\/)?/,
             /(?:(?<user>[a-z_][a-z0-9_-]+)@)?/,
-            /(?<domain>[^\s\/\?#:]+)/,
-            /(?::(?<port>[0-9]{1,5}))?/,
-            /(?:[\/:](?<owner>[^\s\/\?#:]+))?/,
-            /(?:[\/:](?<repo>(?:[^\s\?#:.]|\.(?!git\/?\s*$))+))/,
-            /(?:.git)?\/?\s*$/,
+            /(?<domain>[^\s/?#:]+)/,
+            /(?::(?<port>[0-9]{1,5}):?)?/,
+            /(?:[/:](?<owner>[^\s/?#:]+))?/,
+            /(?:[/:](?<repo>(?:[^\s?#:.]|\.(?!git\/?\s*$))+))/,
+            /(?:(?<suffix>.git))?\/?\s*$/,
         ]
             .map((r) => r.source)
             .join(''),
@@ -145,10 +145,10 @@ export default class GitHelper {
             port: Number(found.groups?.port ?? 22),
             owner: found.groups?.owner ?? '',
             repo: found.groups?.repo,
+            suffix: found.groups?.suffix ?? '',
             get repoPath() {
-                return `ssh://${this.user}@${this.domain}:${this.port}/${
-                    this.owner
-                }${this.owner && '/'}${this.repo}.git`
+                return `ssh://${this.user}@${this.domain}:${this.port}/${this.owner
+                    }${this.owner && '/'}${this.repo}${this.suffix}`
             },
         }
     }

--- a/tests/GitHelper.test.ts
+++ b/tests/GitHelper.test.ts
@@ -24,11 +24,19 @@ test('Testing  - sanitizeRepoPathSsh', () => {
     ).toBe('ssh://git@github.com:22/username/repository.git')
 })
 
-test('Testing  - sanitizeRepoPathSsh', () => {
-    expect(
-        GitHelper.sanitizeRepoPathSsh(' git@gitlab.com/test1/test2/test3.git')
-            .repoPath
-    ).toBe('ssh://git@gitlab.com:22/test1/test2/test3.git')
+test('Testing  - sanitizeRepoPathSsh - with extra path components', () => {
+    const sanitized = GitHelper.sanitizeRepoPathSsh(
+        ' git@gitlab.com/test1/test2/test3.git'
+    );
+    expect(sanitized).toEqual({
+        domain: "gitlab.com",
+        owner: "test1",
+        port: 22,
+        repo: "test2/test3",
+        repoPath: "ssh://git@gitlab.com:22/test1/test2/test3.git",
+        suffix: ".git",
+        user: "git",
+    })
 })
 
 test('Testing  - sanitizeRepoPathSsh - port', () => {
@@ -40,11 +48,18 @@ test('Testing  - sanitizeRepoPathSsh - port', () => {
 })
 
 test('Testing  - sanitizeRepoPathSsh - custom port', () => {
-    expect(
-        GitHelper.sanitizeRepoPathSsh(
-            ' git@github.com:1234/username/repository.git/  '
-        ).port
-    ).toBe(1234)
+    const sanitized = GitHelper.sanitizeRepoPathSsh(
+        ' git@github.com:1234/username/repository.git/  '
+    )
+    expect(sanitized).toEqual({
+        user: "git",
+        domain: "github.com",
+        owner: "username",
+        port: 1234,
+        repo: "repository",
+        suffix: ".git",
+        repoPath: "ssh://git@github.com:1234/username/repository.git",
+    })
 })
 
 test('Testing  - sanitizeRepoPathSsh from HTTPS', () => {
@@ -58,7 +73,7 @@ test('Testing  - sanitizeRepoPathSsh from HTTPS', () => {
 test('Testing  - sanitizeRepoPathSsh - name with dot', () => {
     expect(
         GitHelper.sanitizeRepoPathSsh('  github.com/owner/site.com ').repoPath
-    ).toBe('ssh://git@github.com:22/owner/site.com.git')
+    ).toBe('ssh://git@github.com:22/owner/site.com')
 })
 
 test('Testing  - sanitizeRepoPathSsh - name with dot and git suffix', () => {
@@ -72,7 +87,7 @@ test('Testing  - sanitizeRepoPathSsh - name containing ".git"', () => {
     expect(
         GitHelper.sanitizeRepoPathSsh('  github.com/owner/repo.github ')
             .repoPath
-    ).toBe('ssh://git@github.com:22/owner/repo.github.git')
+    ).toBe('ssh://git@github.com:22/owner/repo.github')
 })
 
 test('Testing  - sanitizeRepoPathSsh - name containing ".git" and git suffix', () => {
@@ -92,7 +107,7 @@ test('Testing  - sanitizeRepoPathSsh - name containing ".git", git suffix and /'
 test('Testing  - sanitizeRepoPathSsh - not git suffix', () => {
     expect(
         GitHelper.sanitizeRepoPathSsh('  github.com/owner/repository ').repoPath
-    ).toBe('ssh://git@github.com:22/owner/repository.git')
+    ).toBe('ssh://git@github.com:22/owner/repository')
 })
 
 test('Testing  - sanitizeRepoPathSsh - alt domain', () => {
@@ -123,6 +138,51 @@ test('Testing  - sanitizeRepoPathSsh - no owner', () => {
         GitHelper.sanitizeRepoPathSsh('  git@github.com:repository.git/ ')
             .repoPath
     ).toBe('ssh://git@github.com:22/repository.git')
+})
+
+test('Testing  - sanitizeRepoPathSsh - with extra path components separated by column', () => {
+    const sanitized = GitHelper.sanitizeRepoPathSsh(
+        '  git@ssh.dev.azure.com:v3/myOrg/My%20Project%20Name/my-repo-name '
+    )
+    expect(sanitized).toEqual({
+        user: 'git',
+        domain: 'ssh.dev.azure.com',
+        port: 22,
+        owner: 'v3',
+        repo: "myOrg/My%20Project%20Name/my-repo-name",
+        repoPath: "ssh://git@ssh.dev.azure.com:22/v3/myOrg/My%20Project%20Name/my-repo-name",
+        suffix: "",
+    })
+})
+
+test('Testing  - sanitizeRepoPathSsh - with extra path components and port separated by column', () => {
+    const sanitized = GitHelper.sanitizeRepoPathSsh(
+        '  git@ssh.dev.azure.com:422:v3/myOrg/My%20Project%20Name/my-repo-name '
+    )
+    expect(sanitized).toEqual({
+        user: "git",
+        domain: 'ssh.dev.azure.com',
+        owner: "v3",
+        port: 422,
+        repo: "myOrg/My%20Project%20Name/my-repo-name",
+        repoPath: "ssh://git@ssh.dev.azure.com:422/v3/myOrg/My%20Project%20Name/my-repo-name",
+        suffix: "",
+    })
+})
+
+test('Testing  - sanitizeRepoPathSsh - with extra path components and "owner" instead of "git" user', () => {
+    const sanitized = GitHelper.sanitizeRepoPathSsh(
+        '  myOrg@vs-ssh.visualstudio.com:v3/myOrg/My%20Project%20Name/my-repo-name '
+    )
+    expect(sanitized).toEqual({
+        user: 'myOrg',
+        domain: 'vs-ssh.visualstudio.com',
+        port: 22,
+        owner: "v3",
+        repo: "myOrg/My%20Project%20Name/my-repo-name",
+        repoPath: "ssh://myOrg@vs-ssh.visualstudio.com:22/v3/myOrg/My%20Project%20Name/my-repo-name",
+        suffix: "",
+    })
 })
 
 test('Testing  - getDomainFromSanitizedSshRepoPath - pure', () => {
@@ -159,4 +219,24 @@ test('Testing  - getDomainFromSanitizedSshRepoPath - alt domain', () => {
             ' ssh://user@some.other-domain.com/owner/repository.git/ '
         )
     ).toBe('some.other-domain.com')
+})
+
+test('Testing  - getDomainFromSanitizedSshRepoPath - with extra path components separated by column', () => {
+    expect(
+        GitHelper.getDomainFromSanitizedSshRepoPath(
+            GitHelper.sanitizeRepoPathSsh(
+                '  git@ssh.dev.azure.com:422:v3/myOrg/My%20Project%20Name/my-repo-name '
+            ).repoPath
+        )
+    ).toBe('ssh.dev.azure.com')
+})
+
+test('Testing  - getDomainFromSanitizedSshRepoPath - with extra path components separated by column and "owner" instead of "git" user', () => {
+    expect(
+        GitHelper.getDomainFromSanitizedSshRepoPath(
+            GitHelper.sanitizeRepoPathSsh(
+                '  myOrg@vs-ssh.visualstudio.com:v3/myOrg/My%20Project%20Name/my-repo-name '
+            ).repoPath
+        )
+    ).toBe('vs-ssh.visualstudio.com')
 })


### PR DESCRIPTION
## Changes

Fixes #2284

- Improve SSH_PATH_RE to ignore extra component paths after port
    ```diff
    - /(?::(?<port>[0-9]{1,5}))?/,
    + /(?::(?<port>[0-9]{1,5}):?)?/,
    ```
- Remove hardcoded `.git` suffix by parsing it if present only (this is necessary because Azure DevOps don't allow `.git` suffix, in my experience most git servers allow clone with and without `.git` suffix, only Azure Devops don't 🥲)
    ```diff
    - /(?:.git)?\/?\s*$/,
    + /(?:(?<suffix>.git))?\/?\s*$/,
    ...
    - return `ssh://${this.user}@${this.domain}:${this.port}/${this.owner
    -  }${this.owner && '/'}${this.repo}.git`
    + return `ssh://${this.user}@${this.domain}:${this.port}/${this.owner
    +  }${this.owner && '/'}${this.repo}${this.suffix}`
    ```  
- Some typo fixings
    
## Evidences

### Cloning GitHub using SSH with `.git` suffix

![Screenshot 2025-03-31 at 10 21 10](https://github.com/user-attachments/assets/9ab2494d-b261-4f99-b22c-d10d32ccef6e)

### Cloning GitHub using SSH without `.git` suffix

![Screenshot 2025-03-31 at 10 20 11](https://github.com/user-attachments/assets/e8154696-e59e-4ac6-a24e-d6cc769d6abd)

### Cloning Azure DevOps using SSH 🎉

![Screenshot 2025-03-31 at 10 22 39](https://github.com/user-attachments/assets/290f43f1-b189-4ccc-b6ca-304da98204fc)

### Tests passing

<img width="780" alt="image" src="https://github.com/user-attachments/assets/54a4842c-2ff0-4b36-9f64-cf80c225dabb" />
