### PR TITLE
If configured with CAPTAIN_HOST_ADMIN_PORT nginx should redirect trafic to 3000 that is the container swarm available port

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -30,7 +30,7 @@ function startServer() {
      * Get port from environment and store in Express.
      */
 
-    const port = 3000
+    const port = CaptainConstants.serviceContainerPort3000
     app.set('port', port)
 
     /**

--- a/src/user/system/LoadBalancerManager.ts
+++ b/src/user/system/LoadBalancerManager.ts
@@ -531,8 +531,8 @@ class LoadBalancerManager {
                         hasRootSsl: hasRootSsl,
                         serviceName: CaptainConstants.captainServiceName,
                         domain: captainDomain,
-                        serviceExposedPort:
-                            CaptainConstants.configs.adminPortNumber3000,
+                        serviceContainerPort3000:
+                            CaptainConstants.serviceContainerPort3000,
                         defaultHtmlDir:
                             CaptainConstants.nginxStaticRootDir +
                             CaptainConstants.nginxDefaultHtmlDir,

--- a/src/utils/CaptainConstants.ts
+++ b/src/utils/CaptainConstants.ts
@@ -92,6 +92,8 @@ const data = {
 
     isDebug: EnvVars.CAPTAIN_IS_DEBUG,
 
+    serviceContainerPort3000: 3000,
+
     rootNameSpace: 'captain',
 
     // *********************** Disk Paths ************************

--- a/src/utils/CaptainInstaller.ts
+++ b/src/utils/CaptainInstaller.ts
@@ -99,7 +99,7 @@ function startServerOnPort_80_443_3000() {
             })
             res.write(FIREWALL_PASSED)
             res.end()
-        }).listen(3000)
+        }).listen(CaptainConstants.serviceContainerPort3000)
 
         return new Promise<void>(function (resolve) {
             setTimeout(function () {
@@ -407,7 +407,7 @@ export function install() {
             ports.push({
                 protocol: 'tcp',
                 publishMode: 'host',
-                containerPort: 3000,
+                containerPort: CaptainConstants.serviceContainerPort3000,
                 hostPort: CaptainConstants.configs.adminPortNumber3000,
             })
 

--- a/template/root-nginx-conf.ejs
+++ b/template/root-nginx-conf.ejs
@@ -86,7 +86,7 @@
         # https://docs.docker.com/engine/userguide/networking/configure-dns/
         # https://github.com/moby/moby/issues/20026
         resolver 127.0.0.11 valid=10s;
-        set $upstream http://<%-captain.serviceName%>:<%-captain.serviceExposedPort%>;
+        set $upstream http://<%-captain.serviceName%>:<%-captain.serviceContainerPort3000%>;
 
         # IMPORTANT!! Except proxy_read_timeout, this block should be same as location /api/v2/user/apps/appData
         location / {


### PR DESCRIPTION
The serviceExposedPort is only used in the template/root-nginx-conf.ejs and should be the container port that is 3000 (used inside swarm). - https://github.com/search?q=repo%3Acaprover%2Fcaprover+serviceExposedPort&type=code

Continues on https://github.com/caprover/caprover/pull/2220 .

Currently nginx cannot forward traffic to admin/3000 port (is using the one defined in configs.adminPortNumber3000).

First of all, thank you for your contribution! 😄
