### PR TITLE
chore: minor comment in dockerfile-captain.release (ko-KR locale contributor)

### DIFF
--- a/dockerfile-captain.release
+++ b/dockerfile-captain.release
@@ -15,5 +15,4 @@ ENV PORT 3000
 EXPOSE 3000
 
 CMD ["node" , "./built/server.js"]
-# Contributor: Added ko-KR locale (frontend translation)
-
+ 

--- a/dockerfile-captain.release
+++ b/dockerfile-captain.release
@@ -15,3 +15,5 @@ ENV PORT 3000
 EXPOSE 3000
 
 CMD ["node" , "./built/server.js"]
+# Contributor: Added ko-KR locale (frontend translation)
+


### PR DESCRIPTION
This PR adds a small comment in `dockerfile-captain.release` 
to ensure contributor recognition for the Korean (ko-KR) frontend localization work.

- No build logic changes
- Purely a comment addition
