### PR TITLE
[HOTFIX] Updated Docker API version

### DIFF
--- a/src/utils/CaptainConstants.ts
+++ b/src/utils/CaptainConstants.ts
@@ -17,7 +17,7 @@ const CONSTANT_FILE_OVERRIDE_USER =
 const configs = {
     publishedNameOnDockerHub: 'caprover/caprover',
 
-    version: '1.14.0',
+    version: '1.14.1',
 
     defaultMaxLogSize: '512m',
 


### PR DESCRIPTION
Hotfix for https://github.com/caprover/caprover/issues/2351

The previous build wasn't pushed: https://github.com/caprover/caprover/commit/78a9b0ce6fe0872e81b43e51ea991908bfd50679

