### PR TITLE
Add support for new ANONYMIZE_IP env in goAccess

### DIFF
--- a/src/routes/user/system/SystemRouter.ts
+++ b/src/routes/user/system/SystemRouter.ts
@@ -464,6 +464,10 @@ router.get('/goaccess/:appName/files/:file', async function (req, res, next) {
                     key: 'FILE_PREFIX',
                     value: `${appName}--${domainName}`,
                 },
+                {
+                    key: 'ANONYMIZE_IP',
+                    value: CaptainConstants.configs.goAccessAnonymizeIP.toString(),
+                },
             ],
             sticky: false,
             wait: true,

--- a/src/user/system/CaptainManager.ts
+++ b/src/user/system/CaptainManager.ts
@@ -748,6 +748,10 @@ class CaptainManager {
                                     goAccessInfo.data.logRetentionDays ?? 180
                                 ).toString(),
                             },
+                            {
+                                key: 'ANONYMIZE_IP',
+                                value: CaptainConstants.configs.goAccessAnonymizeIP.toString(),
+                            },
                         ],
                         [],
                         ['apparmor:unconfined'],

--- a/src/utils/CaptainConstants.ts
+++ b/src/utils/CaptainConstants.ts
@@ -39,7 +39,9 @@ const configs = {
 
     netDataImageName: 'caprover/netdata:v1.34.1',
 
-    goAccessImageName: 'caprover/goaccess:1.9.3',
+    goAccessImageName: 'caprover/goaccess:1.9.4',
+
+    goAccessAnonymizeIP: false,
 
     registryImageName: 'registry:2',
 


### PR DESCRIPTION
A follow-up to https://github.com/caprover/goaccess/pull/2.

This is the bare minimum, but I think this setting should be available through the UI in the future or at least be mentioned somewhere in the docs.
This topic is important for legal reasons in the EU.