### PR TITLE
Add PATCH endpoint for partial app definition updates

### DIFF
--- a/src/handlers/users/apps/appdefinition/AppDefinitionHandler.ts
+++ b/src/handlers/users/apps/appdefinition/AppDefinitionHandler.ts
@@ -190,90 +190,43 @@ export async function patchAppDefinition(
         .getAppsDataStore()
         .getAppDefinition(appName)
 
-    // Merge: use patch value if explicitly provided, otherwise keep existing
-    const merged: UpdateAppDefinitionParams = {
+    // Build base from existing app definition
+    const base: UpdateAppDefinitionParams = {
         appName,
-        projectId:
-            patch.projectId !== undefined
-                ? `${patch.projectId ?? ''}`
-                : existingApp.projectId,
-        description:
-            patch.description !== undefined
-                ? `${patch.description ?? ''}`
-                : existingApp.description,
-        instanceCount:
-            patch.instanceCount !== undefined
-                ? (patch.instanceCount as number | string)
-                : existingApp.instanceCount,
+        projectId: existingApp.projectId,
+        description: existingApp.description,
+        instanceCount: existingApp.instanceCount,
         captainDefinitionRelativeFilePath:
-            patch.captainDefinitionRelativeFilePath !== undefined
-                ? `${patch.captainDefinitionRelativeFilePath ?? ''}`
-                : existingApp.captainDefinitionRelativeFilePath,
-        envVars:
-            patch.envVars !== undefined
-                ? (patch.envVars as IAppEnvVar[])
-                : existingApp.envVars,
-        volumes:
-            patch.volumes !== undefined
-                ? (patch.volumes as IAppVolume[])
-                : existingApp.volumes,
-        tags:
-            patch.tags !== undefined
-                ? (patch.tags as IAppTag[])
-                : existingApp.tags,
-        nodeId:
-            patch.nodeId !== undefined
-                ? `${patch.nodeId ?? ''}`
-                : existingApp.nodeId,
-        notExposeAsWebApp:
-            patch.notExposeAsWebApp !== undefined
-                ? !!patch.notExposeAsWebApp
-                : existingApp.notExposeAsWebApp,
-        containerHttpPort:
-            patch.containerHttpPort !== undefined
-                ? (patch.containerHttpPort as number | string)
-                : existingApp.containerHttpPort,
-        httpAuth:
-            patch.httpAuth !== undefined
-                ? patch.httpAuth
-                : (existingApp as any).httpAuth,
-        forceSsl:
-            patch.forceSsl !== undefined
-                ? !!patch.forceSsl
-                : existingApp.forceSsl,
-        ports:
-            patch.ports !== undefined
-                ? (patch.ports as IAppPort[])
-                : existingApp.ports,
-        repoInfo:
-            patch.appPushWebhook !== undefined
-                ? (patch.appPushWebhook as any)?.repoInfo
-                : existingApp.appPushWebhook?.repoInfo,
-        customNginxConfig:
-            patch.customNginxConfig !== undefined
-                ? `${patch.customNginxConfig ?? ''}`
-                : existingApp.customNginxConfig,
-        redirectDomain:
-            patch.redirectDomain !== undefined
-                ? `${patch.redirectDomain ?? ''}`
-                : existingApp.redirectDomain,
-        preDeployFunction:
-            patch.preDeployFunction !== undefined
-                ? `${patch.preDeployFunction ?? ''}`
-                : existingApp.preDeployFunction,
-        serviceUpdateOverride:
-            patch.serviceUpdateOverride !== undefined
-                ? `${patch.serviceUpdateOverride ?? ''}`
-                : existingApp.serviceUpdateOverride,
-        websocketSupport:
-            patch.websocketSupport !== undefined
-                ? !!patch.websocketSupport
-                : existingApp.websocketSupport,
-        appDeployTokenConfig:
-            patch.appDeployTokenConfig !== undefined
-                ? (patch.appDeployTokenConfig as AppDeployTokenConfig)
-                : existingApp.appDeployTokenConfig,
+            existingApp.captainDefinitionRelativeFilePath,
+        envVars: existingApp.envVars,
+        volumes: existingApp.volumes,
+        tags: existingApp.tags,
+        nodeId: existingApp.nodeId,
+        notExposeAsWebApp: existingApp.notExposeAsWebApp,
+        containerHttpPort: existingApp.containerHttpPort,
+        httpAuth: (existingApp as any).httpAuth,
+        forceSsl: existingApp.forceSsl,
+        ports: existingApp.ports,
+        repoInfo: existingApp.appPushWebhook?.repoInfo,
+        customNginxConfig: existingApp.customNginxConfig,
+        redirectDomain: existingApp.redirectDomain,
+        preDeployFunction: existingApp.preDeployFunction,
+        serviceUpdateOverride: existingApp.serviceUpdateOverride,
+        websocketSupport: existingApp.websocketSupport,
+        appDeployTokenConfig: existingApp.appDeployTokenConfig,
     }
+
+    // Extract only defined patch fields, mapping to UpdateAppDefinitionParams keys
+    const overrides: Partial<UpdateAppDefinitionParams> = {}
+    for (const key of Object.keys(patch)) {
+        if (key === 'appPushWebhook') {
+            overrides.repoInfo = (patch.appPushWebhook as any)?.repoInfo
+        } else if (key in base) {
+            ;(overrides as any)[key] = patch[key]
+        }
+    }
+
+    const merged: UpdateAppDefinitionParams = { ...base, ...overrides }
 
     return updateAppDefinition(merged, serviceManager)
 }

--- a/src/handlers/users/apps/appdefinition/AppDefinitionHandler.ts
+++ b/src/handlers/users/apps/appdefinition/AppDefinitionHandler.ts
@@ -195,19 +195,19 @@ export async function patchAppDefinition(
         appName,
         projectId:
             patch.projectId !== undefined
-                ? `${patch.projectId}`
+                ? `${patch.projectId ?? ''}`
                 : existingApp.projectId,
         description:
             patch.description !== undefined
-                ? `${patch.description}`
+                ? `${patch.description ?? ''}`
                 : existingApp.description,
         instanceCount:
             patch.instanceCount !== undefined
-                ? patch.instanceCount as number | string
+                ? (patch.instanceCount as number | string)
                 : existingApp.instanceCount,
         captainDefinitionRelativeFilePath:
             patch.captainDefinitionRelativeFilePath !== undefined
-                ? `${patch.captainDefinitionRelativeFilePath}`
+                ? `${patch.captainDefinitionRelativeFilePath ?? ''}`
                 : existingApp.captainDefinitionRelativeFilePath,
         envVars:
             patch.envVars !== undefined
@@ -223,7 +223,7 @@ export async function patchAppDefinition(
                 : existingApp.tags,
         nodeId:
             patch.nodeId !== undefined
-                ? `${patch.nodeId}`
+                ? `${patch.nodeId ?? ''}`
                 : existingApp.nodeId,
         notExposeAsWebApp:
             patch.notExposeAsWebApp !== undefined
@@ -251,19 +251,19 @@ export async function patchAppDefinition(
                 : existingApp.appPushWebhook?.repoInfo,
         customNginxConfig:
             patch.customNginxConfig !== undefined
-                ? `${patch.customNginxConfig}`
+                ? `${patch.customNginxConfig ?? ''}`
                 : existingApp.customNginxConfig,
         redirectDomain:
             patch.redirectDomain !== undefined
-                ? `${patch.redirectDomain}`
+                ? `${patch.redirectDomain ?? ''}`
                 : existingApp.redirectDomain,
         preDeployFunction:
             patch.preDeployFunction !== undefined
-                ? `${patch.preDeployFunction}`
+                ? `${patch.preDeployFunction ?? ''}`
                 : existingApp.preDeployFunction,
         serviceUpdateOverride:
             patch.serviceUpdateOverride !== undefined
-                ? `${patch.serviceUpdateOverride}`
+                ? `${patch.serviceUpdateOverride ?? ''}`
                 : existingApp.serviceUpdateOverride,
         websocketSupport:
             patch.websocketSupport !== undefined

--- a/src/routes/user/apps/appdefinition/AppDefinitionRouter.ts
+++ b/src/routes/user/apps/appdefinition/AppDefinitionRouter.ts
@@ -3,6 +3,7 @@ import ApiStatusCodes from '../../../../api/ApiStatusCodes'
 import BaseApi from '../../../../api/BaseApi'
 import {
     getAllAppDefinitions,
+    patchAppDefinition,
     registerAppDefinition,
     updateAppDefinition,
 } from '../../../../handlers/users/apps/appdefinition/AppDefinitionHandler'
@@ -308,6 +309,32 @@ router.post('/update/', function (req, res, next) {
         },
         serviceManager
     )
+        .then(function (result) {
+            res.send(new BaseApi(ApiStatusCodes.STATUS_OK, result.message))
+        })
+        .catch(ApiStatusCodes.createCatcher(res))
+})
+
+// Partial update - only provided fields are changed, omitted fields keep existing values
+router.patch('/update/', function (req, res, next) {
+    const dataStore =
+        InjectionExtractor.extractUserFromInjected(res).user.dataStore
+    const serviceManager =
+        InjectionExtractor.extractUserFromInjected(res).user.serviceManager
+
+    const appName = req.body.appName
+
+    if (!appName) {
+        res.send(
+            new BaseApi(
+                ApiStatusCodes.ILLEGAL_PARAMETER,
+                'appName is required'
+            )
+        )
+        return
+    }
+
+    return patchAppDefinition(appName, req.body, dataStore, serviceManager)
         .then(function (result) {
             res.send(new BaseApi(ApiStatusCodes.STATUS_OK, result.message))
         })

--- a/src/routes/user/apps/appdefinition/AppDefinitionRouter.ts
+++ b/src/routes/user/apps/appdefinition/AppDefinitionRouter.ts
@@ -326,10 +326,7 @@ router.patch('/update/', function (req, res, next) {
 
     if (!appName) {
         res.send(
-            new BaseApi(
-                ApiStatusCodes.ILLEGAL_PARAMETER,
-                'appName is required'
-            )
+            new BaseApi(ApiStatusCodes.ILLEGAL_PARAMETER, 'appName is required')
         )
         return
     }

--- a/tests/PatchAppDefinition.test.ts
+++ b/tests/PatchAppDefinition.test.ts
@@ -1,0 +1,241 @@
+/**
+ * TEST FILE: PatchAppDefinition.test.ts
+ *
+ * Tests the `patchAppDefinition` handler which partially updates an app
+ * definition by merging only the provided fields with existing values.
+ *
+ * This ensures that operations like scaling (changing instanceCount) do not
+ * accidentally wipe env vars, volumes, ports, or other app configuration.
+ */
+
+import { patchAppDefinition } from '../src/handlers/users/apps/appdefinition/AppDefinitionHandler'
+import { IAppDef } from '../src/models/AppDefinition'
+
+const mockExistingApp: IAppDef = {
+    description: 'My test app',
+    deployedVersion: 5,
+    notExposeAsWebApp: false,
+    hasPersistentData: false,
+    hasDefaultSubDomainSsl: true,
+    containerHttpPort: 3000,
+    captainDefinitionRelativeFilePath: './captain-definition',
+    forceSsl: true,
+    websocketSupport: true,
+    nodeId: 'node-abc',
+    instanceCount: 2,
+    preDeployFunction: 'console.log("pre")',
+    serviceUpdateOverride: '',
+    customNginxConfig: '',
+    redirectDomain: '',
+    networks: ['captain-overlay-network'],
+    customDomain: [],
+    tags: [{ tagName: 'production' }],
+    ports: [{ containerPort: 3000, hostPort: 3000, protocol: 'tcp' }],
+    volumes: [
+        {
+            containerPath: '/data',
+            volumeName: 'app-data',
+        },
+    ],
+    envVars: [
+        { key: 'API_HOST', value: 'https://api.example.com' },
+        { key: 'API_KEY', value: 'secret-key-123' },
+        { key: 'DB_URL', value: 'postgres://localhost/mydb' },
+    ],
+    versions: [],
+    appDeployTokenConfig: { enabled: true, appDeployToken: 'tok-123' },
+    appPushWebhook: {
+        tokenVersion: 'v1',
+        repoInfo: {
+            repo: 'my-repo',
+            branch: 'main',
+            user: 'my-user',
+            password: 'my-pass',
+        },
+        pushWebhookToken: 'webhook-tok',
+    },
+    httpAuth: { user: 'admin', password: 'pass123' },
+}
+
+// Track what updateAppDefinition receives via the serviceManager mock
+let capturedUpdateArgs: any[] = []
+
+const mockDataStore = {
+    getAppsDataStore: () => ({
+        getAppDefinition: jest.fn().mockResolvedValue(mockExistingApp),
+    }),
+} as any
+
+const mockServiceManager = {
+    updateAppDefinition: jest.fn().mockImplementation((...args: any[]) => {
+        capturedUpdateArgs = args
+        return Promise.resolve()
+    }),
+    ensureNotBuilding: jest.fn().mockResolvedValue(undefined),
+    dataStore: mockDataStore,
+} as any
+
+describe('patchAppDefinition', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        capturedUpdateArgs = []
+    })
+
+    it('should preserve all existing fields when only instanceCount is provided', async () => {
+        await patchAppDefinition(
+            'my-app',
+            { appName: 'my-app', instanceCount: 1 },
+            mockDataStore,
+            mockServiceManager
+        )
+
+        expect(mockServiceManager.updateAppDefinition).toHaveBeenCalledTimes(1)
+
+        // serviceManager.updateAppDefinition positional args:
+        // 0=appName, 1=projectId, 2=description, 3=instanceCount, 4=captainDefPath,
+        // 5=envVars, 6=volumes, 7=tags, 8=nodeId, 9=notExposeAsWebApp,
+        // 10=containerHttpPort, 11=httpAuth, 12=forceSsl, 13=ports,
+        // 14=repoInfo, 15=customNginxConfig, 16=redirectDomain,
+        // 17=preDeployFunction, 18=serviceUpdateOverride, 19=websocketSupport,
+        // 20=appDeployTokenConfig
+        const args = capturedUpdateArgs
+        expect(args[0]).toBe('my-app') // appName
+        expect(args[3]).toBe(1) // instanceCount — patched
+
+        // envVars (arg 5) should be preserved
+        expect(args[5]).toEqual(mockExistingApp.envVars)
+        expect(args[5]).toHaveLength(3)
+
+        // volumes (arg 6) preserved
+        expect(args[6]).toEqual(mockExistingApp.volumes)
+
+        // tags (arg 7) preserved
+        expect(args[7]).toEqual(mockExistingApp.tags)
+
+        // forceSsl (arg 12) preserved
+        expect(args[12]).toBe(true)
+
+        // websocketSupport (arg 19) preserved
+        expect(args[19]).toBe(true)
+    })
+
+    it('should preserve env vars when scaling to zero', async () => {
+        await patchAppDefinition(
+            'my-app',
+            { appName: 'my-app', instanceCount: 0 },
+            mockDataStore,
+            mockServiceManager
+        )
+
+        const args = capturedUpdateArgs
+        expect(args[3]).toBe(0) // instanceCount
+        expect(args[5]).toEqual(mockExistingApp.envVars) // envVars preserved
+        expect(args[5]).toHaveLength(3)
+    })
+
+    it('should update only the provided fields', async () => {
+        await patchAppDefinition(
+            'my-app',
+            {
+                appName: 'my-app',
+                instanceCount: 3,
+                description: 'Updated description',
+                forceSsl: false,
+            },
+            mockDataStore,
+            mockServiceManager
+        )
+
+        const args = capturedUpdateArgs
+        expect(args[3]).toBe(3) // instanceCount — patched
+        expect(args[2]).toBe('Updated description') // description — patched
+        expect(args[12]).toBe(false) // forceSsl — patched
+
+        // Non-provided fields preserved
+        expect(args[5]).toEqual(mockExistingApp.envVars)
+        expect(args[6]).toEqual(mockExistingApp.volumes)
+        expect(args[19]).toBe(true) // websocketSupport preserved
+    })
+
+    it('should allow updating env vars explicitly', async () => {
+        const newEnvVars = [{ key: 'NEW_VAR', value: 'new-value' }]
+
+        await patchAppDefinition(
+            'my-app',
+            { appName: 'my-app', envVars: newEnvVars },
+            mockDataStore,
+            mockServiceManager
+        )
+
+        const args = capturedUpdateArgs
+        expect(args[5]).toEqual(newEnvVars) // envVars — patched
+        expect(args[5]).toHaveLength(1)
+        expect(args[3]).toBe(2) // instanceCount preserved from existing
+    })
+
+    it('should allow setting envVars to empty array explicitly', async () => {
+        await patchAppDefinition(
+            'my-app',
+            { appName: 'my-app', envVars: [] },
+            mockDataStore,
+            mockServiceManager
+        )
+
+        const args = capturedUpdateArgs
+        expect(args[5]).toEqual([]) // envVars — explicitly emptied
+        expect(args[3]).toBe(2) // instanceCount preserved
+        expect(args[6]).toEqual(mockExistingApp.volumes) // volumes preserved
+    })
+
+    it('should throw error when appName is missing', async () => {
+        await expect(
+            patchAppDefinition(
+                '',
+                { instanceCount: 1 },
+                mockDataStore,
+                mockServiceManager
+            )
+        ).rejects.toThrow()
+    })
+
+    it('should preserve httpAuth from existing app', async () => {
+        await patchAppDefinition(
+            'my-app',
+            { appName: 'my-app', instanceCount: 1 },
+            mockDataStore,
+            mockServiceManager
+        )
+
+        const args = capturedUpdateArgs
+        // httpAuth is arg 11
+        expect(args[11]).toEqual(mockExistingApp.httpAuth)
+    })
+
+    it('should handle multiple fields updated at once', async () => {
+        await patchAppDefinition(
+            'my-app',
+            {
+                appName: 'my-app',
+                instanceCount: 5,
+                containerHttpPort: 8080,
+                websocketSupport: false,
+                notExposeAsWebApp: true,
+                redirectDomain: 'example.com',
+            },
+            mockDataStore,
+            mockServiceManager
+        )
+
+        const args = capturedUpdateArgs
+        expect(args[3]).toBe(5) // instanceCount
+        expect(args[10]).toBe(8080) // containerHttpPort
+        expect(args[19]).toBe(false) // websocketSupport
+        expect(args[9]).toBe(true) // notExposeAsWebApp
+        expect(args[16]).toBe('example.com') // redirectDomain
+
+        // Non-provided preserved
+        expect(args[5]).toEqual(mockExistingApp.envVars)
+        expect(args[12]).toBe(true) // forceSsl
+        expect(args[2]).toBe('My test app') // description
+    })
+})


### PR DESCRIPTION
## Problem

The current `POST /api/v2/user/apps/appDefinitions/update/` endpoint replaces **all** app definition fields on every call. Any field omitted from the request body is reset to its default value:

- `envVars` → `[]` (all environment variables wiped)
- `instanceCount` → `0` (app scaled to zero)
- `forceSsl` → `false`
- `volumes` → `[]`
- etc.

This makes simple operations like **scaling an app** extremely dangerous. Sending `{"appName": "my-app", "instanceCount": 1}` to start an app will silently wipe all environment variables, volumes, ports, SSL settings, and other configuration.

### Real-world impact

This happened to us in production: we used the CLI to scale an app from 0 to 1 instance, and it wiped all 11 environment variables. The app crashed on startup because its configuration was gone. We had to recover the env vars from a previous API response we happened to have cached locally.

The only current workaround is to:
1. `GET` the full app definition
2. Modify the desired field
3. `POST` back the entire object

This is error-prone and requires callers to know about every field to avoid data loss.

## Solution

Add a new `PATCH /api/v2/user/apps/appDefinitions/update/` endpoint that performs **partial updates**. It:

1. Fetches the existing app definition from the data store
2. Merges only the explicitly provided fields from the request body
3. Preserves all omitted fields at their current values
4. Delegates to the existing `updateAppDefinition` handler for validation and persistence

### Example usage

Scale an app without touching any other settings:
```bash
PATCH /api/v2/user/apps/appDefinitions/update/
{"appName": "my-app", "instanceCount": 1}
```

Update only env vars:
```bash
PATCH /api/v2/user/apps/appDefinitions/update/
{"appName": "my-app", "envVars": [{"key": "NEW_VAR", "value": "value"}]}
```

### Backward compatibility

- The existing `POST` endpoint is **completely unchanged**
- The `PATCH` endpoint reuses the same `updateAppDefinition` handler internally
- All existing API clients, the frontend dashboard, and the CLI continue to work exactly as before
- The `PATCH` method is the REST-standard way to express partial updates

## Tests

Added 8 test cases covering:
- Scaling preserves all existing fields (envVars, volumes, ports, tags, SSL, etc.)
- Scaling to zero preserves env vars
- Partial updates only change provided fields
- Explicit env var replacement works
- Explicitly setting envVars to `[]` works (intentional clear)
- Missing `appName` throws error
- `httpAuth` is preserved from existing app
- Multiple fields updated simultaneously

All 91 existing tests continue to pass.

## Files changed

- `src/handlers/users/apps/appdefinition/AppDefinitionHandler.ts` — Added `patchAppDefinition` function
- `src/routes/user/apps/appdefinition/AppDefinitionRouter.ts` — Added `PATCH /update/` route
- `tests/PatchAppDefinition.test.ts` — 8 new test cases