### PR TITLE
fix: allow app names to start with a number (#2276)

### DIFF
--- a/src/datastore/AppsDataStore.ts
+++ b/src/datastore/AppsDataStore.ts
@@ -33,6 +33,7 @@ function isNameAllowed(name: string) {
         /^[a-z0-9]/.test(name) &&
         /[a-z0-9]$/.test(name) &&
         /^[a-z0-9\-]+$/.test(name) &&
+        /[a-z]/.test(name) &&
         name.indexOf('--') < 0
     return isNameFormattingOk && ['captain', 'registry'].indexOf(name) < 0
 }

--- a/src/datastore/ProjectsDataStore.ts
+++ b/src/datastore/ProjectsDataStore.ts
@@ -10,11 +10,11 @@ function isNameAllowed(name: string) {
     const isNameFormattingOk =
         !!name &&
         name.length < 50 &&
-        /^[a-z]/.test(name) &&
+        /^[a-z0-9]/.test(name) &&
         /[a-z0-9]$/.test(name) &&
         /^[a-z0-9\-]+$/.test(name) &&
         name.indexOf('--') < 0
-    return isNameFormattingOk && ['captain', 'root'].indexOf(name) < 0
+    return isNameFormattingOk && ['captain', 'registry'].indexOf(name) < 0
 }
 
 function isValidUUID(uuid: string | undefined): boolean {

--- a/src/datastore/ProjectsDataStore.ts
+++ b/src/datastore/ProjectsDataStore.ts
@@ -13,6 +13,7 @@ function isNameAllowed(name: string) {
         /^[a-z0-9]/.test(name) &&
         /[a-z0-9]$/.test(name) &&
         /^[a-z0-9\-]+$/.test(name) &&
+        /[a-z]/.test(name) &&
         name.indexOf('--') < 0
     return isNameFormattingOk && ['captain', 'registry'].indexOf(name) < 0
 }


### PR DESCRIPTION
### Summary

This PR updates the validation logic in `AppsDataStore.ts` and `ProjectsDataStore.ts` to allow application names to start with a number.

### Why?

Previously, app name validation blocked names starting with digits. This change removes that restriction, enabling users to follow naming conventions that begin with numbers.

### Checklist

* [x] I have read the contribution guidelines.
* [x] This is a small fix (<50 lines) and does not require prior Slack communication.
* [x] Only a logic adjustment for validation; no refactoring involved.