### PR TITLE
Add environment variable handling to project registration and management

### DIFF
--- a/src/datastore/ProjectsDataStore.ts
+++ b/src/datastore/ProjectsDataStore.ts
@@ -94,11 +94,26 @@ class ProjectsDataStore {
                     }
                 }
 
+                const envVars = (project.envVars || []).map((v) => ({
+                    key: `${v.key || ''}`,
+                    value: `${v.value || ''}`,
+                }))
+
+                for (const envVar of envVars) {
+                    if (!envVar.key) {
+                        throw ApiStatusCodes.createError(
+                            ApiStatusCodes.ILLEGAL_OPERATION,
+                            'Project env var key cannot be empty'
+                        )
+                    }
+                }
+
                 const projectToSave: ProjectDefinition = {
                     id: project.id,
                     name: project.name,
                     parentProjectId: project.parentProjectId,
                     description: project.description,
+                    envVars: envVars,
                 }
 
                 self.data.set(

--- a/src/handlers/users/ProjectHandler.ts
+++ b/src/handlers/users/ProjectHandler.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from 'uuid'
 import DataStore from '../../datastore/DataStore'
+import { IAppEnvVar } from '../../models/AppDefinition'
 import { ProjectDefinition } from '../../models/ProjectDefinition'
 import Logger from '../../utils/Logger'
 import { BaseHandlerResult } from '../BaseHandlerResult'
@@ -8,6 +9,7 @@ export interface RegisterProjectParams {
     name: string
     parentProjectId?: string
     description: string
+    envVars?: IAppEnvVar[]
 }
 
 export interface RegisterProjectResult extends BaseHandlerResult {
@@ -18,7 +20,7 @@ export async function registerProject(
     params: RegisterProjectParams,
     dataStore: DataStore
 ): Promise<RegisterProjectResult> {
-    const { name, parentProjectId, description } = params
+    const { name, parentProjectId, description, envVars } = params
 
     Logger.d(`Creating project: ${name}`)
 
@@ -31,6 +33,7 @@ export async function registerProject(
                 name: name,
                 parentProjectId: parentProjectId,
                 description: description,
+                envVars: envVars || [],
             })
 
         Logger.d(`Project created: ${name}`)

--- a/src/models/ProjectDefinition.ts
+++ b/src/models/ProjectDefinition.ts
@@ -1,6 +1,9 @@
+import { IAppEnvVar } from './AppDefinition'
+
 export interface ProjectDefinition {
     id: string
     name: string
     description: string
     parentProjectId?: string
+    envVars?: IAppEnvVar[]
 }

--- a/src/routes/user/ProjectsRouter.ts
+++ b/src/routes/user/ProjectsRouter.ts
@@ -15,9 +15,10 @@ router.post('/register/', function (req, res, next) {
     const projectName = `${req.body.name || ''}`.trim()
     const parentProjectId = `${req.body.parentProjectId || ''}`.trim()
     const description = `${req.body.description || ''}`.trim()
+    const envVars = req.body.envVars || []
 
     return registerProject(
-        { name: projectName, parentProjectId, description },
+        { name: projectName, parentProjectId, description, envVars },
         dataStore
     )
         .then(function (result) {
@@ -91,6 +92,7 @@ router.post('/update/', function (req, res, next) {
                     name: projectDefinition.name,
                     parentProjectId: projectDefinition.parentProjectId,
                     description: projectDefinition.description,
+                    envVars: projectDefinition.envVars || [],
                 })
         })
         .then(function () {

--- a/src/user/ServiceManager.ts
+++ b/src/user/ServiceManager.ts
@@ -13,6 +13,7 @@ import {
 } from '../models/AppDefinition'
 import { DockerAuthObj } from '../models/DockerAuthObj'
 import { IHashMapGeneric } from '../models/ICacheGeneric'
+import { ProjectDefinition } from '../models/ProjectDefinition'
 import { IImageSource } from '../models/IImageSource'
 import { PreDeployFunction } from '../models/OtherTypes'
 import CaptainConstants from '../utils/CaptainConstants'
@@ -187,15 +188,17 @@ class ServiceManager {
                     .getAppsDataStore()
                     .getAppDefinition(appName)
                     .then(function (app) {
-                        const envVars = app.envVars || []
-
-                        return self.imageMaker.ensureImage(
-                            source,
-                            appName,
-                            app.captainDefinitionRelativeFilePath,
-                            appVersion,
-                            envVars
-                        )
+                        return self
+                            .resolveEnvVarsWithInheritance(app)
+                            .then(function (mergedEnvVars) {
+                                return self.imageMaker.ensureImage(
+                                    source,
+                                    appName,
+                                    app.captainDefinitionRelativeFilePath,
+                                    appVersion,
+                                    mergedEnvVars
+                                )
+                            })
                     })
             })
             .then(function (builtImage) {
@@ -885,6 +888,45 @@ class ServiceManager {
             })
     }
 
+    private mergeEnvVars(base: IAppEnvVar[], override: IAppEnvVar[]): IAppEnvVar[] {
+        const map = new Map<string, string>()
+        base.forEach((v) => map.set(v.key, v.value))
+        override.forEach((v) => map.set(v.key, v.value))
+        return Array.from(map.entries()).map(([key, value]) => ({ key, value }))
+    }
+
+    private resolveEnvVarsWithInheritance(app: IAppDef): Promise<IAppEnvVar[]> {
+        const self = this
+        const appEnvVars = app.envVars || []
+
+        if (!app.projectId) {
+            return Promise.resolve(appEnvVars)
+        }
+
+        return self.dataStore
+            .getProjectsDataStore()
+            .getAllProjects()
+            .then(function (allProjects: ProjectDefinition[]) {
+                const projectMap = new Map<string, ProjectDefinition>()
+                allProjects.forEach((p) => projectMap.set(p.id, p))
+
+                const chain: ProjectDefinition[] = []
+                let current = projectMap.get(app.projectId!)
+                while (current) {
+                    chain.unshift(current)
+                    current = current.parentProjectId
+                        ? projectMap.get(current.parentProjectId)
+                        : undefined
+                }
+
+                let merged: IAppEnvVar[] = []
+                for (const project of chain) {
+                    merged = self.mergeEnvVars(merged, project.envVars || [])
+                }
+                return self.mergeEnvVars(merged, appEnvVars)
+            })
+    }
+
     ensureServiceInitedAndUpdated(appName: string) {
         Logger.d(`Ensure service inited and Updated for: ${appName}`)
         const self = this
@@ -905,6 +947,10 @@ class ServiceManager {
             })
             .then(function (appFound) {
                 app = appFound
+                return self.resolveEnvVarsWithInheritance(app)
+            })
+            .then(function (mergedEnvVars) {
+                app = { ...app, envVars: mergedEnvVars }
 
                 Logger.d(`Check if service is running: ${serviceName}`)
                 return dockerApi.isServiceRunningByName(serviceName)


### PR DESCRIPTION
### What does this PR do?

Adds `envVars` support to Projects. Apps and sub-projects that belong to a project inherit its env vars at both build-time and runtime. Child vars override parent vars by key, and the chain resolves from the root project down to the app.

Changes:
- `models/ProjectDefinition.ts`: adds `envVars?: IAppEnvVar[]`
- `datastore/ProjectsDataStore.ts`: validates (no empty keys) and persists `envVars`
- `handlers/users/ProjectHandler.ts`: threads `envVars` through project registration
- `routes/user/ProjectsRouter.ts`: passes `envVars` in both register and update routes
- `user/ServiceManager.ts`: adds `mergeEnvVars` and `resolveEnvVarsWithInheritance`; merged vars are applied in both the Docker service update path and the image build path

### Why is this needed?

Apps sharing common config (e.g. `DATABASE_URL`) currently require setting the same var on every app manually. Project-level env vars eliminate that duplication while still allowing per-app overrides.

### Is this a breaking change?

No. `envVars` is optional and defaults to `[]`. Existing projects without the field are unaffected.