### PR TITLE
Hotfix nginx

### DIFF
--- a/src/utils/CaptainConstants.ts
+++ b/src/utils/CaptainConstants.ts
@@ -17,7 +17,7 @@ const CONSTANT_FILE_OVERRIDE_USER =
 const configs = {
     publishedNameOnDockerHub: 'caprover/caprover',
 
-    version: '1.14.1',
+    version: '1.14.2',
 
     defaultMaxLogSize: '512m',
 

--- a/src/utils/CaptainConstants.ts
+++ b/src/utils/CaptainConstants.ts
@@ -43,7 +43,7 @@ const configs = {
 
     appPlaceholderImageName: 'caprover/caprover-placeholder-app:latest',
 
-    nginxImageName: 'nginx:1.27.2',
+    nginxImageName: 'nginx:1.31',
 
     defaultEmail: 'runner@caprover.com',
 


### PR DESCRIPTION
Hotfix nginx 
https://depthfirst.com/research/nginx-rift-achieving-nginx-rce-via-an-18-year-old-vulnerability


Note: CapRover does not include any `rewrite` directives that would result in this vulnerability. However, we are publishing this hotfix out of an abundance of caution to protect users who may have manually modified their Nginx config.
