### PR TITLE
Captain/Nginx/Certbot stuck in Restart Loop

### DIFF
--- a/src/docker/DockerApi.ts
+++ b/src/docker/DockerApi.ts
@@ -109,6 +109,21 @@ class DockerApi {
         return dockerApiInstance
     }
 
+    // The /version endpoint is unversioned on the Docker Engine, but dockerode
+    // prepends `options.version` to every request path. Pinning a specific API
+    // version here means the probe breaks the moment the daemon's minimum
+    // supported version moves past it (see issue #2401: "client version 1.38
+    // is too old"). Dropping the key keeps the probe at unversioned /version.
+    static buildVersionProbeOptions(
+        connectionParams: Docker.DockerOptions
+    ): Docker.DockerOptions {
+        const probeOptions = JSON.parse(
+            JSON.stringify(connectionParams)
+        ) as Docker.DockerOptions & { version?: string }
+        delete probeOptions.version
+        return probeOptions
+    }
+
     ensureSwarmExists() {
         const self = this
 
@@ -1788,10 +1803,7 @@ const connectionParams: Docker.DockerOptions =
 connectionParams.version = CaptainConstants.configs.dockerApiVersion
 const dockerApiInstance = new DockerApi(connectionParams)
 
-const lowVersionDocker = JSON.parse(JSON.stringify(connectionParams))
-lowVersionDocker.version = 'v1.44'
-
-new Docker(lowVersionDocker)
+new Docker(DockerApi.buildVersionProbeOptions(connectionParams))
     .version()
     .then((data) => {
         Logger.d('Docker API Version on host: ' + data.ApiVersion)

--- a/tests/DockerApiVersionProbe.test.ts
+++ b/tests/DockerApiVersionProbe.test.ts
@@ -1,0 +1,38 @@
+import DockerApi from '../src/docker/DockerApi'
+
+describe('DockerApi.buildVersionProbeOptions', () => {
+    test('removes the version key so dockerode hits the unversioned /version endpoint', () => {
+        // The Docker daemon will reject any client API version below its
+        // minimum supported one (e.g., "client version 1.38 is too old"). The
+        // probe must not pin a version - the /version endpoint itself is
+        // unversioned and supported on every daemon. See issue #2401.
+        const probeOptions = DockerApi.buildVersionProbeOptions({
+            socketPath: '/var/run/docker.sock',
+            version: 'v1.38',
+        }) as { socketPath?: string; version?: string }
+
+        expect(probeOptions.version).toBeUndefined()
+        expect(probeOptions.socketPath).toBe('/var/run/docker.sock')
+    })
+
+    test('preserves host/port and other connection params while dropping version', () => {
+        const probeOptions = DockerApi.buildVersionProbeOptions({
+            host: 'docker.example.com',
+            port: 2375,
+            version: 'v1.44',
+        }) as { host?: string; port?: number; version?: string }
+
+        expect(probeOptions.host).toBe('docker.example.com')
+        expect(probeOptions.port).toBe(2375)
+        expect(probeOptions.version).toBeUndefined()
+    })
+
+    test('does not mutate the caller-provided connection params', () => {
+        const connectionParams = {
+            socketPath: '/var/run/docker.sock',
+            version: 'v1.44',
+        }
+        DockerApi.buildVersionProbeOptions(connectionParams)
+        expect(connectionParams.version).toBe('v1.44')
+    })
+})


### PR DESCRIPTION
### Most important items

Fixes the Docker API version probe in `src/docker/DockerApi.ts` so it targets the unversioned `/version` endpoint instead of pinning a stale `v1.38`/`v1.44` path that newer daemons reject with `client version is too old`, which left `dockerNeedsUpdate` unset and the upgrade guard silently broken. Added `DockerApi.buildVersionProbeOptions` to clone `connectionParams` and strip the `version` key before constructing the probe, plus a unit test in `tests/DockerApiVersionProbe.test.ts`.

Closes #2401