### PR TITLE
Set base nginx worker_processes to auto

### DIFF
--- a/template/base-nginx-conf.ejs
+++ b/template/base-nginx-conf.ejs
@@ -1,5 +1,5 @@
 user  nginx;
-worker_processes  1;
+worker_processes  auto;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;


### PR DESCRIPTION
## Summary
- Change default `worker_processes` in `template/base-nginx-conf.ejs` from `1` to `auto`
- With a single worker, multi-core CPUs are largely underutilized; `auto` lets nginx use one worker per CPU core

## Context
Current defaults roughly limit concurrency to ~512 concurrent requests per process (`1 × 1024 / 2`). High traffic, long-lived connections, or large uploads hit this ceiling first. Switching to `auto` is the standard nginx recommendation for production.

`worker_connections` is left at `1024` (unchanged in this PR).

## Test plan
- [x] Deploy CapRover / regenerate base nginx config and confirm `worker_processes auto;` is present
- [x] Reload nginx and verify worker count matches CPU cores (`ps aux | grep nginx` / nginx status)
- [x] Smoke-test reverse-proxy traffic to an app after reload