### PR TITLE
feat: support project selection when deploying one-click apps

### DIFF
--- a/src/routes/user/oneclick/OneClickAppRouter.ts
+++ b/src/routes/user/oneclick/OneClickAppRouter.ts
@@ -284,6 +284,8 @@ router.post('/deploy', function (req, res, next) {
     const template = req.body.template
     const values = req.body.values
     const templateName = req.body.templateName
+    const projectId =
+        typeof req.body.projectId === 'string' ? req.body.projectId : undefined
     const deploymentJobRegistry = OneClickDeploymentJobRegistry.getInstance()
 
     return Promise.resolve() //
@@ -312,7 +314,7 @@ router.post('/deploy', function (req, res, next) {
                         `Deployment state: ${JSON.stringify(deploymentState, null, 2)}`
                     )
                 }
-            ).startDeployProcess(template, values)
+            ).startDeployProcess(template, values, projectId)
 
             const baseApi = new BaseApi(
                 ApiStatusCodes.STATUS_OK,

--- a/src/user/oneclick/OneClickAppDeployManager.ts
+++ b/src/user/oneclick/OneClickAppDeployManager.ts
@@ -9,6 +9,7 @@ import Utils from '../../utils/Utils'
 import ServiceManager from '../ServiceManager'
 import OneClickAppDeploymentHelper from './OneClickAppDeploymentHelper'
 export const ONE_CLICK_APP_NAME_VAR_NAME = '$$cap_appname'
+export const ONE_CLICK_PROJECT_ID_VAR_NAME = '$$cap_project_id'
 
 interface IDeploymentStep {
     stepName: string
@@ -48,15 +49,24 @@ export default class OneClickAppDeployManager {
 
     startDeployProcess(
         template: IOneClickTemplate,
-        valuesArray: OneClickAppValuePair[]
+        valuesArray: OneClickAppValuePair[],
+        projectId?: string
     ) {
         const self = this
         let stringified = JSON.stringify(template)
 
         const values: IHashMapGeneric<string> = {}
-        valuesArray.forEach((element) => {
+        ;(valuesArray || []).forEach((element) => {
             values[element.key] = element.value
         })
+
+        // Prefer explicit projectId argument; fall back to a reserved values key
+        // so older API clients can still pass a selected project without a new field.
+        const selectedProjectId = (
+            projectId ||
+            values[ONE_CLICK_PROJECT_ID_VAR_NAME] ||
+            ''
+        ).trim()
 
         if (
             template.caproverOneClickApp.variables.find(
@@ -120,7 +130,13 @@ export default class OneClickAppDeployManager {
             const steps: IDeploymentStep[] = []
             const capAppName = values[ONE_CLICK_APP_NAME_VAR_NAME]
 
-            const projectMemoryCache = { projectId: '' }
+            // Single-service templates place the app under the selected project.
+            // Multi-service templates still create a grouping project, using the
+            // selected project as its parent (root when empty).
+            const projectMemoryCache = {
+                projectId: selectedProjectId,
+                parentProjectId: selectedProjectId,
+            }
 
             if (apps.length > 1) {
                 steps.push(
@@ -249,7 +265,7 @@ export default class OneClickAppDeployManager {
     }
     private createDeploymentStepForProjectCreation(
         capAppName: string,
-        projectMemoryCache: { projectId: string }
+        projectMemoryCache: { projectId: string; parentProjectId?: string }
     ): IDeploymentStep {
         const self = this
         return {
@@ -267,7 +283,7 @@ export default class OneClickAppDeployManager {
         appName: string,
         dockerComposeService: IDockerComposeService,
         capAppName: string,
-        projectMemoryCache: { projectId: string }
+        projectMemoryCache: { projectId: string; parentProjectId?: string }
     ): IDeploymentStep[] {
         const promises: IDeploymentStep[] = []
         const self = this

--- a/src/user/oneclick/OneClickAppDeploymentHelper.ts
+++ b/src/user/oneclick/OneClickAppDeploymentHelper.ts
@@ -101,7 +101,8 @@ export default class OneClickAppDeploymentHelper {
                 id: '',
                 name: appName,
                 description: ``,
-                parentProjectId: projectMemoryCache.parentProjectId || undefined,
+                parentProjectId:
+                    projectMemoryCache.parentProjectId || undefined,
             }
             // change backend to ensure this returns project ID
             return self.apiManager

--- a/src/user/oneclick/OneClickAppDeploymentHelper.ts
+++ b/src/user/oneclick/OneClickAppDeploymentHelper.ts
@@ -78,7 +78,7 @@ export default class OneClickAppDeploymentHelper {
     createRegisterPromise(
         appName: string,
         dockerComposeService: IDockerComposeService,
-        projectMemoryCache: { projectId: string }
+        projectMemoryCache: { projectId: string; parentProjectId?: string }
     ) {
         const self = this
         return Promise.resolve().then(function () {
@@ -93,7 +93,7 @@ export default class OneClickAppDeploymentHelper {
     }
     createRegisterPromiseProject(
         appName: string,
-        projectMemoryCache: { projectId: string }
+        projectMemoryCache: { projectId: string; parentProjectId?: string }
     ) {
         const self = this
         return Promise.resolve().then(function () {
@@ -101,6 +101,7 @@ export default class OneClickAppDeploymentHelper {
                 id: '',
                 name: appName,
                 description: ``,
+                parentProjectId: projectMemoryCache.parentProjectId || undefined,
             }
             // change backend to ensure this returns project ID
             return self.apiManager


### PR DESCRIPTION
## Summary
Allows selecting a CapRover project when deploying a one-click app, similar to the existing parent project selector when creating or editing an app.

### Backend
- Accept optional `projectId` on `POST /user/oneclick/deploy`
- Also accept reserved value `$$cap_project_id` for older API clients
- **Single-service** templates: register the app under the selected project
- **Multi-service** templates: still create a grouping project, using the selected project as its parent (root when empty)

### Companion frontend PR
- https://github.com/bestony/caprover-frontend/tree/agent/pi-musk/6783907e (will open against caprover/caprover-frontend)

## Motivation
Users currently cannot assign a project when deploying from the one-click apps UI; they have to reassign the app after deploy. This matches the UX of “Create a new app” / app details.

## Test plan
- [ ] Deploy a single-service one-click app with a selected project → app appears under that project
- [ ] Deploy a multi-service one-click app with a selected project → grouping project is created as a child of the selected project
- [ ] Deploy with no project selected (root) → behavior unchanged from before
- [ ] Existing clients that do not send `projectId` continue to work