### PR TITLE
Prevent malformed config from being overwritten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Improved: Descriptive error on installations on incompatible systems (e.g. Proxmox LXC) [issues-2326](https://github.com/caprover/caprover/issues/2326)
 - Improved: Moved one click app creation process to backend for more stability [PR-2334](https://github.com/caprover/caprover/pull/2334)
 - Improved: Reduced the Backup size by excluding the GoAccess logs [PR-2336](https://github.com/caprover/caprover/pull/2336)
+- Fixed: Prevented malformed `config-captain.json` from being overwritten [Issue-858](https://github.com/caprover/caprover/issues/858)
 
 ## [1.14.2] - 2026-05-14
 

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -38,6 +38,24 @@ const CURRENT_THEME = 'currentTheme'
 
 const DEFAULT_CAPTAIN_ROOT_DOMAIN = 'captain.localhost'
 
+export function validateConfigFile(configPath: string) {
+    if (!fs.pathExistsSync(configPath)) {
+        return
+    }
+
+    try {
+        JSON.parse(fs.readFileSync(configPath, 'utf8'))
+    } catch (error) {
+        if (error instanceof SyntaxError) {
+            throw new Error(
+                `Cannot start CapRover because ${configPath} contains invalid JSON. Fix the file or restore it from a backup, then restart CapRover.`
+            )
+        }
+
+        throw error
+    }
+}
+
 const DEFAULT_NGINX_BASE_CONFIG = fs
     .readFileSync(__dirname + '/../../template/base-nginx-conf.ejs')
     .toString()
@@ -69,11 +87,14 @@ class DataStore {
     private projectsDataStore: ProjectsDataStore
 
     constructor(namespace: string) {
+        const configPath = `${CaptainConstants.captainDataDirectory}/config-${namespace}.json`
+        validateConfigFile(configPath)
+
         const data = new Configstore(
             `captain-store-${namespace}`, // This value seems to be unused
             {},
             {
-                configPath: `${CaptainConstants.captainDataDirectory}/config-${namespace}.json`,
+                configPath,
             }
         )
 

--- a/tests/DataStore.test.ts
+++ b/tests/DataStore.test.ts
@@ -1,0 +1,42 @@
+import fs = require('fs-extra')
+import os = require('os')
+import path = require('path')
+import { validateConfigFile } from '../src/datastore/DataStore'
+
+describe('DataStore config validation', () => {
+    let tempDirectory: string
+
+    beforeEach(() => {
+        tempDirectory = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'caprover-config-')
+        )
+    })
+
+    afterEach(() => {
+        fs.removeSync(tempDirectory)
+    })
+
+    test('does not modify a malformed config file', () => {
+        const configPath = path.join(tempDirectory, 'config-captain.json')
+        const malformedConfig = '{"namespace":"captain",}'
+        fs.writeFileSync(configPath, malformedConfig)
+
+        expect(() => validateConfigFile(configPath)).toThrow(
+            `Cannot start CapRover because ${configPath} contains invalid JSON.`
+        )
+        expect(fs.readFileSync(configPath, 'utf8')).toBe(malformedConfig)
+    })
+
+    test('accepts a valid config file', () => {
+        const configPath = path.join(tempDirectory, 'config-captain.json')
+        fs.writeJsonSync(configPath, { namespace: 'captain' })
+
+        expect(() => validateConfigFile(configPath)).not.toThrow()
+    })
+
+    test('accepts a missing config file on first startup', () => {
+        const configPath = path.join(tempDirectory, 'config-captain.json')
+
+        expect(() => validateConfigFile(configPath)).not.toThrow()
+    })
+})


### PR DESCRIPTION
## What changed

- Validate `config-captain.json` before constructing `Configstore`
- Abort startup with an actionable error when the file contains invalid JSON
- Preserve malformed configuration files so administrators can repair or restore them
- Add regression tests for malformed, valid, and missing configuration files

## Root cause

`configstore@5.0.1` empties its backing file when JSON parsing fails. CapRover then writes the `namespace` field, replacing the existing configuration with a nearly empty file.

## Validation

- Focused regression tests: 3 passed
- Build: passed
- Lint: passed
- Formatting: passed
- Full suite: all 15 suites and 98 runnable tests passed, but Jest exited nonzero because an existing asynchronous Docker socket check logged after test completion (`EPERM /var/run/docker.sock`)

Closes #858

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed `config-captain.json` files are no longer overwritten.
  * Valid configuration files continue to load normally.
  * Missing configuration files are accepted during initial startup.
  * Git webhook deployments support payloads larger than 100 KB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->