### PR TITLE
Observe expiring orphaned SSL certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Improved: Descriptive error on installations on incompatible systems (e.g. Proxmox LXC) [issues-2326](https://github.com/caprover/caprover/issues/2326)
 - Improved: Moved one click app creation process to backend for more stability [PR-2334](https://github.com/caprover/caprover/pull/2334)
 - Improved: Reduced the Backup size by excluding the GoAccess logs [PR-2336](https://github.com/caprover/caprover/pull/2336)
-- Fixed: Removed orphaned SSL certificates shortly before expiration to prevent failed renewal attempts [Issue-2397](https://github.com/caprover/caprover/issues/2397)
+- Improved: Logged orphaned SSL certificates shortly before expiration for a safe observation period [Issue-2397](https://github.com/caprover/caprover/issues/2397)
 - Fixed: Prevented malformed `config-captain.json` from being overwritten [Issue-858](https://github.com/caprover/caprover/issues/858)
 - Fixed: Git webhook deployments failing when webhook payloads exceed 100 KB [Issue-1393](https://github.com/caprover/caprover/issues/1393)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Improved: Descriptive error on installations on incompatible systems (e.g. Proxmox LXC) [issues-2326](https://github.com/caprover/caprover/issues/2326)
 - Improved: Moved one click app creation process to backend for more stability [PR-2334](https://github.com/caprover/caprover/pull/2334)
 - Improved: Reduced the Backup size by excluding the GoAccess logs [PR-2336](https://github.com/caprover/caprover/pull/2336)
-- Improved: Logged orphaned SSL certificates shortly before expiration for a safe observation period [Issue-2397](https://github.com/caprover/caprover/issues/2397)
+- Improved: Logged expired or soon-to-expire orphaned SSL certificates for a safe observation period [Issue-2397](https://github.com/caprover/caprover/issues/2397)
 - Fixed: Prevented malformed `config-captain.json` from being overwritten [Issue-858](https://github.com/caprover/caprover/issues/858)
 - Fixed: Git webhook deployments failing when webhook payloads exceed 100 KB [Issue-1393](https://github.com/caprover/caprover/issues/1393)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Improved: Descriptive error on installations on incompatible systems (e.g. Proxmox LXC) [issues-2326](https://github.com/caprover/caprover/issues/2326)
 - Improved: Moved one click app creation process to backend for more stability [PR-2334](https://github.com/caprover/caprover/pull/2334)
 - Improved: Reduced the Backup size by excluding the GoAccess logs [PR-2336](https://github.com/caprover/caprover/pull/2336)
+- Fixed: Removed orphaned SSL certificates shortly before expiration to prevent failed renewal attempts [Issue-2397](https://github.com/caprover/caprover/issues/2397)
 - Fixed: Prevented malformed `config-captain.json` from being overwritten [Issue-858](https://github.com/caprover/caprover/issues/858)
 - Fixed: Git webhook deployments failing when webhook payloads exceed 100 KB [Issue-1393](https://github.com/caprover/caprover/issues/1393)
 

--- a/src/user/system/CertbotManager.ts
+++ b/src/user/system/CertbotManager.ts
@@ -1,3 +1,4 @@
+import { X509Certificate } from 'crypto'
 import ApiStatusCodes from '../../api/ApiStatusCodes'
 import DockerApi from '../../docker/DockerApi'
 import CaptainConstants, {
@@ -14,6 +15,25 @@ const WEBROOT_PATH_IN_CAPTAIN =
     CaptainConstants.nginxDomainSpecificHtmlDir
 
 const shouldUseStaging = false // CaptainConstants.isDebug;
+const ORPHAN_CERTIFICATE_EXPIRY_THRESHOLD_MS = 48 * 60 * 60 * 1000
+const CERTBOT_RENEWAL_CONFIG_DIRECTORY =
+    CaptainConstants.letsEncryptEtcPath + '/renewal'
+
+export function shouldDeleteOrphanedCertificate(
+    certificateName: string,
+    activeDomains: string[],
+    expiryDate: number,
+    currentTime = Date.now()
+): boolean {
+    const activeDomainSet = new Set(
+        activeDomains.map((domain) => domain.toLowerCase())
+    )
+
+    return (
+        !activeDomainSet.has(certificateName.toLowerCase()) &&
+        expiryDate <= currentTime + ORPHAN_CERTIFICATE_EXPIRY_THRESHOLD_MS
+    )
+}
 
 function isCertCommandSuccess(output: string) {
     // https://github.com/certbot/certbot/blob/099c6c8b240400b928d6b349e023e5e8414611e6/certbot/certbot/_internal/main.py#L516
@@ -268,7 +288,79 @@ class CertbotManager {
             })
     }
 
-    renewAllCerts() {
+    cleanupExpiringOrphanedCertificates(activeDomains: string[]) {
+        const self = this
+
+        return fs
+            .readdir(CERTBOT_RENEWAL_CONFIG_DIRECTORY)
+            .then(function (renewalConfigFiles) {
+                let cleanupPromise = Promise.resolve()
+
+                renewalConfigFiles
+                    .filter((fileName) => fileName.endsWith('.conf'))
+                    .map((fileName) => fileName.slice(0, -'.conf'.length))
+                    .forEach((certificateName) => {
+                        cleanupPromise = cleanupPromise.then(function () {
+                            try {
+                                self.domainValidOrThrow(certificateName)
+                            } catch (error) {
+                                Logger.e(
+                                    `Skipping invalid Certbot certificate name ${certificateName}: ${error}`
+                                )
+                                return
+                            }
+
+                            const certificatePath =
+                                CaptainConstants.letsEncryptEtcPath +
+                                `/live/${certificateName}/cert.pem`
+
+                            return fs
+                                .readFile(certificatePath)
+                                .then(function (certificatePem) {
+                                    const certificate = new X509Certificate(
+                                        certificatePem
+                                    )
+                                    const expiryDate = Date.parse(
+                                        certificate.validTo
+                                    )
+
+                                    if (
+                                        Number.isNaN(expiryDate) ||
+                                        !shouldDeleteOrphanedCertificate(
+                                            certificateName,
+                                            activeDomains,
+                                            expiryDate
+                                        )
+                                    ) {
+                                        return
+                                    }
+
+                                    return self
+                                        .runCommand([
+                                            'certbot',
+                                            'delete',
+                                            '--cert-name',
+                                            certificateName,
+                                        ])
+                                        .then(function () {
+                                            Logger.d(
+                                                `Deleted orphaned certificate nearing expiration: ${certificateName}`
+                                            )
+                                        })
+                                })
+                                .catch(function (error) {
+                                    Logger.e(
+                                        `Skipping cleanup for certificate ${certificateName}: ${error}`
+                                    )
+                                })
+                        })
+                    })
+
+                return cleanupPromise
+            })
+    }
+
+    renewAllCerts(activeDomains: string[]) {
         const self = this
 
         /*
@@ -282,24 +374,47 @@ class CertbotManager {
             it can be run as frequently as you want - since it will usually take no action.
          */
 
-        const cmd = ['certbot', 'renew']
-
-        if (shouldUseStaging) {
-            cmd.push('--staging')
-        }
-
-        return Promise.resolve() //
-            .then(function () {
-                return self.ensureAllCurrentlyRegisteredDomainsHaveDirs()
+        return self
+            .cleanupExpiringOrphanedCertificates(activeDomains)
+            .catch(function (error) {
+                // Cleanup must never prevent active certificates from renewing.
+                Logger.e(
+                    `Orphaned certificate cleanup failed; continuing with active certificate renewal: ${error}`
+                )
             })
             .then(function () {
-                return self.runCommand(cmd)
-            })
-            .then(function (output) {
-                // Ignore output :)
-            })
-            .catch(function (err) {
-                Logger.e(err)
+                let renewalPromise = Promise.resolve()
+
+                activeDomains.forEach((domainName) => {
+                    renewalPromise = renewalPromise.then(function () {
+                        const cmd = [
+                            'certbot',
+                            'renew',
+                            '--cert-name',
+                            domainName,
+                        ]
+
+                        if (shouldUseStaging) {
+                            cmd.push('--staging')
+                        }
+
+                        return self
+                            .ensureDomainHasDirectory(domainName)
+                            .then(function () {
+                                return self.runCommand(cmd)
+                            })
+                            .then(function () {
+                                // Ignore output :)
+                            })
+                            .catch(function (error) {
+                                Logger.e(
+                                    `Failed to renew certificate ${domainName}: ${error}`
+                                )
+                            })
+                    })
+                })
+
+                return renewalPromise
             })
     }
 

--- a/src/user/system/CertbotManager.ts
+++ b/src/user/system/CertbotManager.ts
@@ -19,7 +19,7 @@ const ORPHAN_CERTIFICATE_EXPIRY_THRESHOLD_MS = 48 * 60 * 60 * 1000
 const CERTBOT_RENEWAL_CONFIG_DIRECTORY =
     CaptainConstants.letsEncryptEtcPath + '/renewal'
 
-export function shouldDeleteOrphanedCertificate(
+export function isExpiringOrphanedCertificate(
     certificateName: string,
     activeDomains: string[],
     expiryDate: number,
@@ -288,7 +288,7 @@ class CertbotManager {
             })
     }
 
-    cleanupExpiringOrphanedCertificates(activeDomains: string[]) {
+    logExpiringOrphanedCertificates(activeDomains: string[]) {
         const self = this
 
         return fs
@@ -326,7 +326,7 @@ class CertbotManager {
 
                                     if (
                                         Number.isNaN(expiryDate) ||
-                                        !shouldDeleteOrphanedCertificate(
+                                        !isExpiringOrphanedCertificate(
                                             certificateName,
                                             activeDomains,
                                             expiryDate
@@ -335,22 +335,13 @@ class CertbotManager {
                                         return
                                     }
 
-                                    return self
-                                        .runCommand([
-                                            'certbot',
-                                            'delete',
-                                            '--cert-name',
-                                            certificateName,
-                                        ])
-                                        .then(function () {
-                                            Logger.d(
-                                                `Deleted orphaned certificate nearing expiration: ${certificateName}`
-                                            )
-                                        })
+                                    Logger.d(
+                                        `Orphaned certificate eligible for deletion (no action taken): ${certificateName}`
+                                    )
                                 })
                                 .catch(function (error) {
                                     Logger.e(
-                                        `Skipping cleanup for certificate ${certificateName}: ${error}`
+                                        `Skipping orphan candidate check for certificate ${certificateName}: ${error}`
                                     )
                                 })
                         })
@@ -360,7 +351,7 @@ class CertbotManager {
             })
     }
 
-    renewAllCerts(activeDomains: string[]) {
+    renewAllCerts() {
         const self = this
 
         /*
@@ -374,47 +365,24 @@ class CertbotManager {
             it can be run as frequently as you want - since it will usually take no action.
          */
 
-        return self
-            .cleanupExpiringOrphanedCertificates(activeDomains)
-            .catch(function (error) {
-                // Cleanup must never prevent active certificates from renewing.
-                Logger.e(
-                    `Orphaned certificate cleanup failed; continuing with active certificate renewal: ${error}`
-                )
+        const cmd = ['certbot', 'renew']
+
+        if (shouldUseStaging) {
+            cmd.push('--staging')
+        }
+
+        return Promise.resolve() //
+            .then(function () {
+                return self.ensureAllCurrentlyRegisteredDomainsHaveDirs()
             })
             .then(function () {
-                let renewalPromise = Promise.resolve()
-
-                activeDomains.forEach((domainName) => {
-                    renewalPromise = renewalPromise.then(function () {
-                        const cmd = [
-                            'certbot',
-                            'renew',
-                            '--cert-name',
-                            domainName,
-                        ]
-
-                        if (shouldUseStaging) {
-                            cmd.push('--staging')
-                        }
-
-                        return self
-                            .ensureDomainHasDirectory(domainName)
-                            .then(function () {
-                                return self.runCommand(cmd)
-                            })
-                            .then(function () {
-                                // Ignore output :)
-                            })
-                            .catch(function (error) {
-                                Logger.e(
-                                    `Failed to renew certificate ${domainName}: ${error}`
-                                )
-                            })
-                    })
-                })
-
-                return renewalPromise
+                return self.runCommand(cmd)
+            })
+            .then(function (output) {
+                // Ignore output :)
+            })
+            .catch(function (err) {
+                Logger.e(err)
             })
     }
 

--- a/src/user/system/LoadBalancerManager.ts
+++ b/src/user/system/LoadBalancerManager.ts
@@ -919,6 +919,35 @@ class LoadBalancerManager {
             })
     }
 
+    getActiveSslDomains() {
+        const self = this
+
+        return Promise.all([
+            self.getServerList(),
+            self.dataStore.getHasRootSsl(),
+            self.dataStore.getHasRegistrySsl(),
+        ]).then(function ([servers, hasRootSsl, hasRegistrySsl]) {
+            const activeDomains: string[] = servers
+                .filter((server) => server.hasSsl)
+                .map((server) => server.publicDomain)
+            const rootDomain = self.dataStore.getRootDomain()
+
+            if (hasRootSsl) {
+                activeDomains.push(
+                    `${CaptainConstants.configs.captainSubDomain}.${rootDomain}`
+                )
+            }
+
+            if (hasRegistrySsl) {
+                activeDomains.push(
+                    `${CaptainConstants.registrySubDomain}.${rootDomain}`
+                )
+            }
+
+            return Array.from(new Set(activeDomains))
+        })
+    }
+
     renewAllCertsAndReload() {
         const self = this
 
@@ -936,8 +965,11 @@ class LoadBalancerManager {
             1000 * 3600 * 20.3
         )
 
-        return self.certbotManager
-            .renewAllCerts() //
+        return self
+            .getActiveSslDomains()
+            .then(function (activeDomains) {
+                return self.certbotManager.renewAllCerts(activeDomains)
+            })
             .then(function () {
                 Logger.d('Updating Load Balancer - renewAllCerts')
                 return self.rePopulateNginxConfigFile()

--- a/src/user/system/LoadBalancerManager.ts
+++ b/src/user/system/LoadBalancerManager.ts
@@ -965,14 +965,26 @@ class LoadBalancerManager {
             1000 * 3600 * 20.3
         )
 
-        return self
-            .getActiveSslDomains()
-            .then(function (activeDomains) {
-                return self.certbotManager.renewAllCerts(activeDomains)
-            })
+        return self.certbotManager
+            .renewAllCerts() //
             .then(function () {
                 Logger.d('Updating Load Balancer - renewAllCerts')
                 return self.rePopulateNginxConfigFile()
+            })
+            .then(function () {
+                return self
+                    .getActiveSslDomains()
+                    .then(function (activeDomains) {
+                        return self.certbotManager.logExpiringOrphanedCertificates(
+                            activeDomains
+                        )
+                    })
+                    .catch(function (error) {
+                        // Observation must never affect certificate renewal or NGINX reload.
+                        Logger.e(
+                            `Orphaned certificate observation failed (no action taken): ${error}`
+                        )
+                    })
             })
     }
 }

--- a/tests/CertCommandGenerator.test.ts
+++ b/tests/CertCommandGenerator.test.ts
@@ -1,6 +1,6 @@
 import {
     CertCommandGenerator,
-    shouldDeleteOrphanedCertificate,
+    isExpiringOrphanedCertificate,
 } from '../src/user/system/CertbotManager'
 
 const defaultCommand = 'certbot certonly --domain ${domainName}'
@@ -63,12 +63,12 @@ test('falls back to default command when rule command is null', () => {
         .toEqual([ 'certbot', 'certonly', '--domain', 'nullcommand.com' ])
 })
 
-describe('orphaned certificate cleanup', () => {
+describe('orphaned certificate observation', () => {
     const currentTime = Date.parse('2026-07-16T12:00:00Z')
 
-    test('deletes orphaned certificates expiring within 48 hours', () => {
+    test('flags orphaned certificates expiring within 48 hours', () => {
         expect(
-            shouldDeleteOrphanedCertificate(
+            isExpiringOrphanedCertificate(
                 'expired.example.com',
                 [],
                 currentTime - 1,
@@ -76,7 +76,7 @@ describe('orphaned certificate cleanup', () => {
             )
         ).toBe(true)
         expect(
-            shouldDeleteOrphanedCertificate(
+            isExpiringOrphanedCertificate(
                 '48-hours.example.com',
                 [],
                 currentTime + 48 * 60 * 60 * 1000,
@@ -85,9 +85,9 @@ describe('orphaned certificate cleanup', () => {
         ).toBe(true)
     })
 
-    test('keeps orphaned certificates with more than 48 hours remaining', () => {
+    test('does not flag orphaned certificates with more than 48 hours remaining', () => {
         expect(
-            shouldDeleteOrphanedCertificate(
+            isExpiringOrphanedCertificate(
                 '49-hours.example.com',
                 [],
                 currentTime + 49 * 60 * 60 * 1000,
@@ -96,9 +96,9 @@ describe('orphaned certificate cleanup', () => {
         ).toBe(false)
     })
 
-    test('keeps active certificates even when they are expired', () => {
+    test('does not flag active certificates even when they are expired', () => {
         expect(
-            shouldDeleteOrphanedCertificate(
+            isExpiringOrphanedCertificate(
                 'active.example.com',
                 ['ACTIVE.EXAMPLE.COM'],
                 currentTime - 1,

--- a/tests/CertCommandGenerator.test.ts
+++ b/tests/CertCommandGenerator.test.ts
@@ -1,4 +1,7 @@
-import { CertCommandGenerator } from '../src/user/system/CertbotManager'
+import {
+    CertCommandGenerator,
+    shouldDeleteOrphanedCertificate,
+} from '../src/user/system/CertbotManager'
 
 const defaultCommand = 'certbot certonly --domain ${domainName}'
 const exampleRule = {
@@ -58,4 +61,49 @@ test('falls back to default command when rule command is null', () => {
     const generator = new CertCommandGenerator([ nullCommandRule ], defaultCommand)
     expect(generator.getCertbotCertCommand('nullcommand.com', fakeWebroot))
         .toEqual([ 'certbot', 'certonly', '--domain', 'nullcommand.com' ])
+})
+
+describe('orphaned certificate cleanup', () => {
+    const currentTime = Date.parse('2026-07-16T12:00:00Z')
+
+    test('deletes orphaned certificates expiring within 48 hours', () => {
+        expect(
+            shouldDeleteOrphanedCertificate(
+                'expired.example.com',
+                [],
+                currentTime - 1,
+                currentTime
+            )
+        ).toBe(true)
+        expect(
+            shouldDeleteOrphanedCertificate(
+                '48-hours.example.com',
+                [],
+                currentTime + 48 * 60 * 60 * 1000,
+                currentTime
+            )
+        ).toBe(true)
+    })
+
+    test('keeps orphaned certificates with more than 48 hours remaining', () => {
+        expect(
+            shouldDeleteOrphanedCertificate(
+                '49-hours.example.com',
+                [],
+                currentTime + 49 * 60 * 60 * 1000,
+                currentTime
+            )
+        ).toBe(false)
+    })
+
+    test('keeps active certificates even when they are expired', () => {
+        expect(
+            shouldDeleteOrphanedCertificate(
+                'active.example.com',
+                ['ACTIVE.EXAMPLE.COM'],
+                currentTime - 1,
+                currentTime
+            )
+        ).toBe(false)
+    })
 })


### PR DESCRIPTION
## Summary

- preserve the existing global `certbot renew` flow unchanged
- identify orphaned certificate lineages from CapRover's active SSL configuration
- read expiration from the actual X.509 certificate instead of parsing Certbot's human-readable output
- log orphaned certificates only when they are within 48 hours of expiration
- take no deletion or mutation action
- run observation only after certificate renewal and NGINX reload complete
- add focused coverage for the 48-hour boundary and active-domain protection

## Why observation only

Automatically deleting certificate lineages is too risky without production evidence that candidate detection matches real CapRover installations. This PR introduces a data-collection phase first.

The log message is:

```
Orphaned certificate eligible for deletion (no action taken): <certificate-name>
```

Operators can collect these events and validate them before any deletion behavior is considered in a future change.

## Safety

The legacy renewal path remains `certbot renew` for all registered certificates, including the existing webroot-directory preparation and error handling.

Observation runs afterward, once renewal and NGINX reload have completed. Discovery, datastore, filesystem, or certificate-parsing failures are caught and logged. They cannot prevent or alter certificate renewal, and this PR contains no `certbot delete` command.

## Validation

- focused tests cover expired and exactly-48-hour orphan candidates
- certificates with more than 48 hours remaining are not logged
- active certificates are never logged as deletion candidates, case-insensitively

Related to #2397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring for SSL certificates no longer associated with currently active domains.
  * Orphaned certificates that will expire within a 48-hour window are logged shortly before expiration for a safe review period.
  * Active-domain SSL consideration is improved to ensure consistent identification of orphaned certificates.
* **Bug Fixes**
  * Certificate observation issues no longer interrupt certificate renewal or service reload operations.
* **Documentation**
  * Updated the changelog to reflect the new orphaned-certificate monitoring behavior.
* **Tests**
  * Added automated coverage for orphaned certificate observation eligibility logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->