### PR TITLE
Allow larger webhook payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Improved: Descriptive error on installations on incompatible systems (e.g. Proxmox LXC) [issues-2326](https://github.com/caprover/caprover/issues/2326)
 - Improved: Moved one click app creation process to backend for more stability [PR-2334](https://github.com/caprover/caprover/pull/2334)
 - Improved: Reduced the Backup size by excluding the GoAccess logs [PR-2336](https://github.com/caprover/caprover/pull/2336)
+- Fixed: Git webhook deployments failing when webhook payloads exceed 100 KB [Issue-1393](https://github.com/caprover/caprover/issues/1393)
 
 ## [1.14.2] - 2026-05-14
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -43,10 +43,15 @@ app.use(
         },
     })
 )
-app.use(bodyParser.json())
+app.use(
+    bodyParser.json({
+        limit: '2mb',
+    })
+)
 app.use(
     bodyParser.urlencoded({
         extended: false,
+        limit: '2mb',
     })
 )
 app.use(cookieParser())

--- a/src/routes/user/apps/webhooks/WebhooksRouter.ts
+++ b/src/routes/user/apps/webhooks/WebhooksRouter.ts
@@ -9,6 +9,7 @@ const router = express.Router()
 
 const urlencodedParser = bodyParser.urlencoded({
     extended: true,
+    limit: '2mb',
 })
 
 function getPushedBranches(req: express.Request) {


### PR DESCRIPTION
## Summary

- increase JSON and URL-encoded request body limits from 100 KB to 2 MB
- apply the same limit to the webhook-specific form parser
- document the fix in the changelog

## Why

GitHub push payloads can exceed body-parser's 100 KB default when many commits are pushed at once. The global parser rejects those requests before the webhook handler runs, so CapRover never schedules the deployment.

A 2 MB bounded limit accepts the 176 KB payload reported in the issue with substantial headroom while continuing to reject unexpectedly large request bodies.

## Validation

- `npm run build`
- `npm run lint`
- `npm run formatter`
- `npm test -- --runInBand` (14 suites, 95 passed, 2 skipped)

Closes #1393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git webhook deployments now support payloads up to 2 MB, preventing failures caused by larger webhook requests.
  * Improved handling of JSON and URL-encoded request bodies with explicit size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->