### PR TITLE
feat(projects): assign app deployments to parent projects

### DIFF
--- a/src/datastore/ProjectsDataStore.ts
+++ b/src/datastore/ProjectsDataStore.ts
@@ -6,7 +6,7 @@ import AppsDataStore from './AppsDataStore'
 
 const PROJECTS_DEFINITIONS = 'projectsDefinitions'
 
-function isNameAllowed(name: string) {
+export function isProjectNameAllowed(name: string) {
     const isNameFormattingOk =
         !!name &&
         name.length < 50 &&
@@ -46,7 +46,7 @@ class ProjectsDataStore {
                     project.parentProjectId || ''
                 }`.trim()
 
-                if (!isNameAllowed(project.name)) {
+                if (!isProjectNameAllowed(project.name)) {
                     throw ApiStatusCodes.createError(
                         ApiStatusCodes.ILLEGAL_OPERATION,
                         'Project name is not allowed'

--- a/src/handlers/users/apps/appdefinition/AppDefinitionHandler.ts
+++ b/src/handlers/users/apps/appdefinition/AppDefinitionHandler.ts
@@ -28,13 +28,16 @@ export async function registerAppDefinition(
     dataStore: DataStore,
     serviceManager: ServiceManager
 ): Promise<BaseHandlerResult> {
-    const { appName, projectId, hasPersistentData, isDetachedBuild } = params
+    const { appName, hasPersistentData, isDetachedBuild } = params
+    const projectId = `${params.projectId || ''}`.trim()
     let appCreated = false
 
-    Logger.d(`Registering app started: ${appName}`)
+    Logger.d(
+        `Registering app started: ${appName}; parent project selected: ${!!projectId}`
+    )
 
     try {
-        // Validate project if projectId is provided
+        // Validate the normalized project ID before writing the app.
         if (projectId) {
             await dataStore.getProjectsDataStore().getProject(projectId)
             // if project is not found, it will throw an error
@@ -71,12 +74,18 @@ export async function registerAppDefinition(
             await promiseToIgnore
         }
 
-        Logger.d(`AppName is saved: ${appName}`)
+        Logger.d(
+            `AppName is saved: ${appName}; projectId: ${projectId || 'root'}`
+        )
 
         return {
             message: 'App Definition Saved',
         }
     } catch (error: any) {
+        Logger.e(
+            error,
+            `Failed to register app: ${appName}; project selected: ${!!projectId}`
+        )
         // Cleanup if app was created but something failed
         if (appCreated) {
             try {

--- a/src/routes/user/apps/appdefinition/AppDefinitionRouter.ts
+++ b/src/routes/user/apps/appdefinition/AppDefinitionRouter.ts
@@ -164,7 +164,7 @@ router.post('/register/', function (req, res, next) {
         InjectionExtractor.extractUserFromInjected(res).user.serviceManager
 
     const appName = req.body.appName as string
-    const projectId = `${req.body.projectId || ''}`
+    const projectId = `${req.body.projectId || ''}`.trim()
     const hasPersistentData = !!req.body.hasPersistentData
     const isDetachedBuild = !!req.query.detached
 

--- a/src/routes/user/oneclick/OneClickAppRouter.ts
+++ b/src/routes/user/oneclick/OneClickAppRouter.ts
@@ -8,7 +8,10 @@ import {
     CapRoverEventFactory,
     CapRoverEventType,
 } from '../../../user/events/ICapRoverEvent'
-import OneClickAppDeployManager from '../../../user/oneclick/OneClickAppDeployManager'
+import OneClickAppDeployManager, {
+    OneClickDeploymentOptions,
+    validateOneClickDeploymentOptions,
+} from '../../../user/oneclick/OneClickAppDeployManager'
 import { OneClickDeploymentJobRegistry } from '../../../user/oneclick/OneClickDeploymentJobRegistry'
 import CaptainConstants from '../../../utils/CaptainConstants'
 import Logger from '../../../utils/Logger'
@@ -283,17 +286,46 @@ router.post('/deploy', function (req, res, next) {
 
     const template = req.body.template
     const values = req.body.values
-    const templateName = req.body.templateName
+    const templateName =
+        req.body.templateName === undefined
+            ? undefined
+            : `${req.body.templateName || ''}`.trim()
+    const deploymentOptions: OneClickDeploymentOptions = {
+        parentProjectId: `${req.body.parentProjectId || ''}`.trim(),
+        templateName,
+    }
+    if (req.body.projectName !== undefined) {
+        deploymentOptions.projectName = `${req.body.projectName || ''}`.trim()
+    }
     const deploymentJobRegistry = OneClickDeploymentJobRegistry.getInstance()
 
     return Promise.resolve() //
-        .then(function () {
+        .then(async function () {
             if (!template) {
                 throw ApiStatusCodes.createError(
                     ApiStatusCodes.ILLEGAL_PARAMETER,
                     'Template is required'
                 )
             }
+
+            await validateOneClickDeploymentOptions(
+                dataStore,
+                template,
+                deploymentOptions,
+                values
+            )
+
+            const deploymentType =
+                templateName === 'DOCKER_COMPOSE'
+                    ? 'docker-compose'
+                    : templateName === 'TEMPLATE_ONE_CLICK'
+                      ? 'custom-one-click'
+                      : templateName
+                        ? 'one-click'
+                        : 'legacy'
+            Logger.d(
+                `One-click deployment validated; type: ${deploymentType}; parent project selected: ${!!deploymentOptions.parentProjectId}`
+            )
 
             const jobId = deploymentJobRegistry.createJob()
 
@@ -307,12 +339,11 @@ router.post('/deploy', function (req, res, next) {
                         jobId,
                         deploymentState
                     )
-                    Logger.dev(`Deployment state updated for jobId: ${jobId}`)
                     Logger.dev(
-                        `Deployment state: ${JSON.stringify(deploymentState, null, 2)}`
+                        `Deployment state updated for jobId: ${jobId}; current step: ${deploymentState.currentStep}; has error: ${!!deploymentState.error}`
                     )
                 }
-            ).startDeployProcess(template, values)
+            ).startDeployProcess(template, values, deploymentOptions)
 
             const baseApi = new BaseApi(
                 ApiStatusCodes.STATUS_OK,

--- a/src/user/oneclick/OneClickAppDeployManager.ts
+++ b/src/user/oneclick/OneClickAppDeployManager.ts
@@ -1,4 +1,5 @@
 import DataStore from '../../datastore/DataStore'
+import ApiStatusCodes from '../../api/ApiStatusCodes'
 import { IHashMapGeneric } from '../../models/ICacheGeneric'
 import {
     IDockerComposeService,
@@ -6,9 +7,100 @@ import {
 } from '../../models/IOneClickAppModels'
 import { OneClickAppValuePair } from '../../models/OneClickApp'
 import Utils from '../../utils/Utils'
+import Logger from '../../utils/Logger'
+import { isProjectNameAllowed } from '../../datastore/ProjectsDataStore'
 import ServiceManager from '../ServiceManager'
 import OneClickAppDeploymentHelper from './OneClickAppDeploymentHelper'
 export const ONE_CLICK_APP_NAME_VAR_NAME = '$$cap_appname'
+
+export interface OneClickDeploymentOptions {
+    parentProjectId?: string
+    projectName?: string
+    templateName?: string
+}
+
+export function getTemplateServiceCount(template: IOneClickTemplate): number {
+    if (
+        !template ||
+        !template.services ||
+        typeof template.services !== 'object'
+    ) {
+        return 0
+    }
+
+    return Object.keys(template.services).length
+}
+
+export function normalizeOneClickDeploymentOptions(
+    options?: OneClickDeploymentOptions
+): OneClickDeploymentOptions {
+    const normalized: OneClickDeploymentOptions = {
+        parentProjectId: `${options?.parentProjectId || ''}`.trim(),
+    }
+
+    if (options && options.projectName !== undefined) {
+        normalized.projectName = `${options.projectName || ''}`.trim()
+    }
+
+    if (options && options.templateName !== undefined) {
+        normalized.templateName = `${options.templateName || ''}`.trim()
+    }
+
+    return normalized
+}
+
+export async function validateOneClickDeploymentOptions(
+    dataStore: DataStore,
+    template: IOneClickTemplate,
+    options?: OneClickDeploymentOptions,
+    valuesArray: OneClickAppValuePair[] = []
+) {
+    const normalizedOptions = normalizeOneClickDeploymentOptions(options)
+    const parentProjectId = normalizedOptions.parentProjectId || ''
+
+    Logger.d(
+        `Validating one-click deployment options; services: ${getTemplateServiceCount(
+            template
+        )}; parent project selected: ${!!parentProjectId}`
+    )
+
+    if (parentProjectId) {
+        await dataStore.getProjectsDataStore().getProject(parentProjectId)
+    }
+
+    const usesOneClickAppName =
+        !!template?.caproverOneClickApp?.variables?.some(
+            (variable) => variable.id === ONE_CLICK_APP_NAME_VAR_NAME
+        )
+    const isDockerCompose =
+        normalizedOptions.templateName === 'DOCKER_COMPOSE' ||
+        (!usesOneClickAppName && normalizedOptions.projectName !== undefined)
+    const safeValuesArray = Array.isArray(valuesArray) ? valuesArray : []
+    const oneClickAppName = `${
+        safeValuesArray.find(
+            (value) => value && value.key === ONE_CLICK_APP_NAME_VAR_NAME
+        )?.value || ''
+    }`.trim()
+
+    if (getTemplateServiceCount(template) > 1) {
+        const projectName = isDockerCompose
+            ? normalizedOptions.projectName || ''
+            : oneClickAppName
+        if (!projectName) {
+            throw ApiStatusCodes.createError(
+                ApiStatusCodes.ILLEGAL_OPERATION,
+                'Project name is required for multi-service deployments'
+            )
+        }
+
+        if (!isProjectNameAllowed(projectName)) {
+            throw ApiStatusCodes.createError(
+                ApiStatusCodes.ILLEGAL_OPERATION,
+                'Project name is not allowed'
+            )
+        }
+    }
+}
 
 interface IDeploymentStep {
     stepName: string
@@ -48,20 +140,26 @@ export default class OneClickAppDeployManager {
 
     startDeployProcess(
         template: IOneClickTemplate,
-        valuesArray: OneClickAppValuePair[]
+        valuesArray: OneClickAppValuePair[] = [],
+        deploymentOptions?: OneClickDeploymentOptions
     ) {
         const self = this
+        const normalizedOptions =
+            normalizeOneClickDeploymentOptions(deploymentOptions)
         let stringified = JSON.stringify(template)
 
         const values: IHashMapGeneric<string> = {}
-        valuesArray.forEach((element) => {
-            values[element.key] = element.value
+        const safeValuesArray = Array.isArray(valuesArray) ? valuesArray : []
+        safeValuesArray.forEach((element) => {
+            if (element && element.key) {
+                values[element.key] = element.value
+            }
         })
 
+        const variables = template.caproverOneClickApp.variables || []
+
         if (
-            template.caproverOneClickApp.variables.find(
-                (v) => v.id === ONE_CLICK_APP_NAME_VAR_NAME
-            ) &&
+            variables.find((v) => v.id === ONE_CLICK_APP_NAME_VAR_NAME) &&
             (!values[ONE_CLICK_APP_NAME_VAR_NAME] ||
                 values[ONE_CLICK_APP_NAME_VAR_NAME].trim().length === 0)
         ) {
@@ -73,12 +171,8 @@ export default class OneClickAppDeployManager {
             return
         }
 
-        for (
-            let index = 0;
-            index < template.caproverOneClickApp.variables.length;
-            index++
-        ) {
-            const element = template.caproverOneClickApp.variables[index]
+        for (let index = 0; index < variables.length; index++) {
+            const element = variables[index]
             stringified = replaceWith(
                 element.id,
                 values[element.id] || '',
@@ -91,7 +185,7 @@ export default class OneClickAppDeployManager {
         } catch (error) {
             this.onDeploymentStateChanged({
                 steps: ['Parsing the template'],
-                error: `Cannot parse: ${stringified}\n\n\n\n${error}`,
+                error: `Cannot parse deployment template: ${error}`,
                 currentStep: 0,
             })
             return
@@ -118,15 +212,36 @@ export default class OneClickAppDeployManager {
             })
         } else {
             const steps: IDeploymentStep[] = []
-            const capAppName = values[ONE_CLICK_APP_NAME_VAR_NAME]
+            const capAppName = `${
+                values[ONE_CLICK_APP_NAME_VAR_NAME] || ''
+            }`.trim()
 
-            const projectMemoryCache = { projectId: '' }
+            const projectMemoryCache = {
+                projectId: normalizedOptions.parentProjectId || '',
+            }
+
+            Logger.d(
+                `Starting one-click deployment; services: ${apps.length}; parent project selected: ${!!projectMemoryCache.projectId}`
+            )
 
             if (apps.length > 1) {
+                const usesOneClickAppName = variables.some(
+                    (variable) => variable.id === ONE_CLICK_APP_NAME_VAR_NAME
+                )
+                const isDockerCompose =
+                    normalizedOptions.templateName === 'DOCKER_COMPOSE' ||
+                    (!usesOneClickAppName &&
+                        normalizedOptions.projectName !== undefined)
+                const groupProjectName =
+                    isDockerCompose &&
+                    normalizedOptions.projectName !== undefined
+                        ? normalizedOptions.projectName
+                        : capAppName
                 steps.push(
                     self.createDeploymentStepForProjectCreation(
-                        capAppName,
-                        projectMemoryCache
+                        groupProjectName,
+                        projectMemoryCache,
+                        projectMemoryCache.projectId
                     )
                 )
             }
@@ -248,16 +363,21 @@ export default class OneClickAppDeployManager {
         return apps
     }
     private createDeploymentStepForProjectCreation(
-        capAppName: string,
-        projectMemoryCache: { projectId: string }
+        projectName: string,
+        projectMemoryCache: { projectId: string },
+        parentProjectId: string
     ): IDeploymentStep {
         const self = this
         return {
-            stepName: `Creating project ${capAppName}`,
+            stepName: `Creating project ${projectName}`,
             stepPromise: function () {
+                Logger.d(
+                    `Creating one-click deployment group project; parent project selected: ${!!parentProjectId}`
+                )
                 return self.deploymentHelper.createRegisterPromiseProject(
-                    capAppName,
-                    projectMemoryCache
+                    projectName,
+                    projectMemoryCache,
+                    parentProjectId
                 )
             },
         }

--- a/src/user/oneclick/OneClickAppDeploymentHelper.ts
+++ b/src/user/oneclick/OneClickAppDeploymentHelper.ts
@@ -92,15 +92,20 @@ export default class OneClickAppDeploymentHelper {
         })
     }
     createRegisterPromiseProject(
-        appName: string,
-        projectMemoryCache: { projectId: string }
+        projectName: string,
+        projectMemoryCache: { projectId: string },
+        parentProjectId: string = ''
     ) {
         const self = this
         return Promise.resolve().then(function () {
             const projectDef: ProjectDefinition = {
                 id: '',
-                name: appName,
+                name: projectName,
                 description: ``,
+            }
+            const normalizedParentProjectId = `${parentProjectId || ''}`.trim()
+            if (normalizedParentProjectId) {
+                projectDef.parentProjectId = normalizedParentProjectId
             }
             // change backend to ensure this returns project ID
             return self.apiManager

--- a/tests/OneClickAppDeployManager.test.ts
+++ b/tests/OneClickAppDeployManager.test.ts
@@ -1,0 +1,302 @@
+import ApiStatusCodes from '../src/api/ApiStatusCodes'
+import { IOneClickTemplate } from '../src/models/IOneClickAppModels'
+import OneClickAppDeployManager, {
+    ONE_CLICK_APP_NAME_VAR_NAME,
+    OneClickDeploymentOptions,
+    validateOneClickDeploymentOptions,
+} from '../src/user/oneclick/OneClickAppDeployManager'
+import OneClickAppDeploymentHelper from '../src/user/oneclick/OneClickAppDeploymentHelper'
+
+function createTemplate(
+    serviceNames: string[],
+    includeAppNameVariable: boolean
+): IOneClickTemplate {
+    const services = serviceNames.reduce((result, serviceName) => {
+        result[serviceName] = { image: `${serviceName}:1` }
+        return result
+    }, {} as any)
+
+    return {
+        captainVersion: 4,
+        services,
+        caproverOneClickApp: {
+            displayName: 'Test template',
+            instructions: {
+                start: 'Starting',
+                end: 'Finished',
+            },
+            variables: includeAppNameVariable
+                ? [
+                      {
+                          id: ONE_CLICK_APP_NAME_VAR_NAME,
+                          label: 'App Name',
+                      },
+                  ]
+                : [],
+        },
+    }
+}
+
+async function deployAndWait(
+    template: IOneClickTemplate,
+    options: OneClickDeploymentOptions,
+    deploymentHelper: any,
+    appName: string = 'bundle'
+) {
+    let resolveFinished: () => void = () => undefined
+    const finished = new Promise<void>((resolve) => {
+        resolveFinished = resolve
+    })
+    const stateChanges: any[] = []
+    const manager = new OneClickAppDeployManager(
+        {} as any,
+        {} as any,
+        (state) => {
+            stateChanges.push(state)
+            if (state.error || state.currentStep >= state.steps.length) {
+                resolveFinished()
+            }
+        }
+    )
+    ;(manager as any).deploymentHelper = deploymentHelper
+
+    const values = template.caproverOneClickApp.variables.length
+        ? [{ key: ONE_CLICK_APP_NAME_VAR_NAME, value: appName }]
+        : []
+    manager.startDeployProcess(template, values, options)
+    await finished
+
+    return stateChanges
+}
+
+describe('OneClickAppDeployManager project assignment', () => {
+    let registrations: Array<{ appName: string; projectId: string }>
+    let deploymentHelper: any
+
+    beforeEach(() => {
+        registrations = []
+        deploymentHelper = {
+            createRegisterPromiseProject: jest.fn(
+                (
+                    projectName: string,
+                    projectMemoryCache: { projectId: string }
+                ) => {
+                    projectMemoryCache.projectId = 'generated-group-id'
+                    return Promise.resolve()
+                }
+            ),
+            createRegisterPromise: jest.fn(
+                (
+                    appName: string,
+                    service: any,
+                    projectMemoryCache: { projectId: string }
+                ) => {
+                    registrations.push({
+                        appName,
+                        projectId: projectMemoryCache.projectId,
+                    })
+                    return Promise.resolve()
+                }
+            ),
+            createConfigurationPromise: jest.fn().mockResolvedValue(undefined),
+            createDeploymentPromise: jest.fn().mockResolvedValue(undefined),
+        }
+    })
+
+    it('assigns a single service directly to the selected project', async () => {
+        await deployAndWait(
+            createTemplate(['web'], true),
+            { parentProjectId: 'parent-id' },
+            deploymentHelper,
+            'web-app'
+        )
+
+        expect(
+            deploymentHelper.createRegisterPromiseProject
+        ).not.toHaveBeenCalled()
+        expect(registrations).toEqual([
+            { appName: 'web', projectId: 'parent-id' },
+        ])
+    })
+
+    it('keeps a root single-service deployment at root', async () => {
+        await deployAndWait(
+            createTemplate(['web'], true),
+            {},
+            deploymentHelper,
+            'web-app'
+        )
+
+        expect(registrations).toEqual([{ appName: 'web', projectId: '' }])
+    })
+
+    it('creates a nested group and assigns every service to it', async () => {
+        await deployAndWait(
+            createTemplate(['database', 'web'], false),
+            {
+                parentProjectId: 'parent-id',
+                projectName: 'compose-stack',
+                templateName: 'DOCKER_COMPOSE',
+            },
+            deploymentHelper
+        )
+
+        expect(
+            deploymentHelper.createRegisterPromiseProject
+        ).toHaveBeenCalledWith(
+            'compose-stack',
+            expect.objectContaining({ projectId: 'generated-group-id' }),
+            'parent-id'
+        )
+        expect(registrations).toEqual([
+            { appName: 'database', projectId: 'generated-group-id' },
+            { appName: 'web', projectId: 'generated-group-id' },
+        ])
+    })
+
+    it('uses the one-click app name for a root group', async () => {
+        await deployAndWait(
+            createTemplate(['database', 'web'], true),
+            {},
+            deploymentHelper,
+            'one-click-stack'
+        )
+
+        expect(
+            deploymentHelper.createRegisterPromiseProject
+        ).toHaveBeenCalledWith('one-click-stack', expect.any(Object), '')
+        expect(
+            registrations.every(
+                (item) => item.projectId === 'generated-group-id'
+            )
+        ).toBe(true)
+    })
+
+    it('keeps $$cap_appname as the group name for one-click templates', async () => {
+        await deployAndWait(
+            createTemplate(['database', 'web'], true),
+            {
+                projectName: 'should-be-ignored',
+                templateName: 'OFFICIAL_TEST',
+            },
+            deploymentHelper,
+            'one-click-stack'
+        )
+
+        expect(
+            deploymentHelper.createRegisterPromiseProject
+        ).toHaveBeenCalledWith('one-click-stack', expect.any(Object), '')
+    })
+})
+
+describe('validateOneClickDeploymentOptions', () => {
+    const getProject = jest.fn()
+    const dataStore = {
+        getProjectsDataStore: () => ({ getProject }),
+    } as any
+    const multiServiceTemplate = createTemplate(['database', 'web'], false)
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        getProject.mockResolvedValue({ id: 'parent-id' })
+    })
+
+    it('validates a trimmed parent project before deployment', async () => {
+        await validateOneClickDeploymentOptions(
+            dataStore,
+            multiServiceTemplate,
+            {
+                parentProjectId: '  parent-id  ',
+                projectName: 'compose-stack',
+                templateName: 'DOCKER_COMPOSE',
+            }
+        )
+
+        expect(getProject).toHaveBeenCalledWith('parent-id')
+    })
+
+    it('preserves the Project not found error for a deleted parent', async () => {
+        getProject.mockRejectedValue(
+            ApiStatusCodes.createError(
+                ApiStatusCodes.ILLEGAL_OPERATION,
+                'Project not found'
+            )
+        )
+
+        await expect(
+            validateOneClickDeploymentOptions(dataStore, multiServiceTemplate, {
+                parentProjectId: 'deleted-parent',
+                projectName: 'compose-stack',
+                templateName: 'DOCKER_COMPOSE',
+            })
+        ).rejects.toMatchObject({
+            captainErrorType: ApiStatusCodes.ILLEGAL_OPERATION,
+            apiMessage: 'Project not found',
+        })
+    })
+
+    it.each(['', 'Invalid Name', 'double--hyphen', 'root'])(
+        'rejects invalid Compose group name %p before deployment',
+        async (projectName) => {
+            await expect(
+                validateOneClickDeploymentOptions(
+                    dataStore,
+                    multiServiceTemplate,
+                    {
+                        projectName,
+                        templateName: 'DOCKER_COMPOSE',
+                    }
+                )
+            ).rejects.toMatchObject({
+                captainErrorType: ApiStatusCodes.ILLEGAL_OPERATION,
+            })
+
+            expect(getProject).not.toHaveBeenCalled()
+        }
+    )
+
+    it('rejects an invalid one-click group name before deployment', async () => {
+        await expect(
+            validateOneClickDeploymentOptions(
+                dataStore,
+                createTemplate(['database', 'web'], true),
+                {},
+                [
+                    {
+                        key: ONE_CLICK_APP_NAME_VAR_NAME,
+                        value: 'Invalid Name',
+                    },
+                ]
+            )
+        ).rejects.toMatchObject({
+            captainErrorType: ApiStatusCodes.ILLEGAL_OPERATION,
+        })
+
+        expect(getProject).not.toHaveBeenCalled()
+    })
+})
+
+describe('OneClickAppDeploymentHelper project creation', () => {
+    it('passes the selected parent to the generated group project', async () => {
+        const helper = new OneClickAppDeploymentHelper({} as any, {} as any)
+        const registerProject = jest.fn().mockResolvedValue({
+            data: { id: 'generated-group-id' },
+        })
+        ;(helper as any).apiManager = { registerProject }
+        const projectMemoryCache = { projectId: 'parent-id' }
+
+        await helper.createRegisterPromiseProject(
+            'compose-stack',
+            projectMemoryCache,
+            'parent-id'
+        )
+
+        expect(registerProject).toHaveBeenCalledWith({
+            id: '',
+            name: 'compose-stack',
+            description: '',
+            parentProjectId: 'parent-id',
+        })
+        expect(projectMemoryCache.projectId).toBe('generated-group-id')
+    })
+})

--- a/tests/RegisterAppDefinition.test.ts
+++ b/tests/RegisterAppDefinition.test.ts
@@ -1,0 +1,107 @@
+import ApiStatusCodes from '../src/api/ApiStatusCodes'
+import { registerAppDefinition } from '../src/handlers/users/apps/appdefinition/AppDefinitionHandler'
+
+describe('registerAppDefinition', () => {
+    const getProject = jest.fn()
+    const saveApp = jest.fn()
+    const deleteApp = jest.fn()
+    const scheduleDeploy = jest.fn()
+
+    const dataStore = {
+        getProjectsDataStore: () => ({ getProject }),
+        getAppsDataStore: () => ({
+            registerAppDefinition: saveApp,
+            deleteAppDefinition: deleteApp,
+        }),
+    } as any
+
+    const serviceManager = {
+        scheduleDeployNewVersion: scheduleDeploy,
+    } as any
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        getProject.mockResolvedValue({ id: 'project-id' })
+        saveApp.mockResolvedValue(undefined)
+        deleteApp.mockResolvedValue(undefined)
+        scheduleDeploy.mockResolvedValue(undefined)
+    })
+
+    it('validates and saves an existing project ID', async () => {
+        await registerAppDefinition(
+            {
+                appName: 'test-app',
+                projectId: 'project-id',
+                hasPersistentData: false,
+                isDetachedBuild: false,
+            },
+            dataStore,
+            serviceManager
+        )
+
+        expect(getProject).toHaveBeenCalledWith('project-id')
+        expect(saveApp).toHaveBeenCalledWith('test-app', 'project-id', false)
+        expect(scheduleDeploy).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses the same trimmed project ID for validation and persistence', async () => {
+        await registerAppDefinition(
+            {
+                appName: 'trimmed-app',
+                projectId: '  project-id  ',
+                hasPersistentData: true,
+                isDetachedBuild: false,
+            },
+            dataStore,
+            serviceManager
+        )
+
+        expect(getProject).toHaveBeenCalledWith('project-id')
+        expect(saveApp).toHaveBeenCalledWith('trimmed-app', 'project-id', true)
+    })
+
+    it.each(['', '   '])('treats %p as the root project', async (projectId) => {
+        await registerAppDefinition(
+            {
+                appName: 'root-app',
+                projectId,
+                hasPersistentData: false,
+                isDetachedBuild: false,
+            },
+            dataStore,
+            serviceManager
+        )
+
+        expect(getProject).not.toHaveBeenCalled()
+        expect(saveApp).toHaveBeenCalledWith('root-app', '', false)
+    })
+
+    it('does not write or deploy when the project does not exist', async () => {
+        getProject.mockRejectedValue(
+            ApiStatusCodes.createError(
+                ApiStatusCodes.ILLEGAL_OPERATION,
+                'Project not found'
+            )
+        )
+
+        await expect(
+            registerAppDefinition(
+                {
+                    appName: 'orphan-app',
+                    projectId: 'deleted-project',
+                    hasPersistentData: false,
+                    isDetachedBuild: false,
+                },
+                dataStore,
+                serviceManager
+            )
+        ).rejects.toMatchObject({
+            captainErrorType: ApiStatusCodes.ILLEGAL_OPERATION,
+            apiMessage: 'Project not found',
+        })
+
+        expect(saveApp).not.toHaveBeenCalled()
+        expect(scheduleDeploy).not.toHaveBeenCalled()
+        expect(deleteApp).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Summary

- Preserve the existing `/apps` home flow while keeping normal app creation project assignment intact.
- Validate and normalize parent project IDs for app-definition and one-click deployment requests.
- Support parent-project nesting for official one-click, custom one-click, and Docker Compose deployments.
- Create multi-service deployment group projects under the selected parent project.
- Keep legacy clients that omit the new fields compatible.

## Verification

- `npm run formatter`
- `npm run lint`
- `npm run build`
- `npm test -- --silent` (16 suites, 113 passed, 2 skipped)
- Manual local deployment flow verified by the requester.

## Review notes

The matching frontend change is submitted separately to `caprover/caprover-frontend`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * One-click deployments now support selecting a parent project and custom project names.
  * Multi-service deployments create and organize projects more consistently.
  * Added validation for deployment templates, project names, and parent project selections.
* **Bug Fixes**
  * Project IDs are now trimmed consistently, with whitespace-only values treated as root-level projects.
  * Improved handling of invalid project selections and deployment options.
  * Deployment errors provide clearer, safer messages.
* **Tests**
  * Added coverage for project assignment, option validation, and app-definition registration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->