### PR TITLE
Preserve legacy DNS names for new app services

### DIFF
--- a/src/docker/DockerApi.ts
+++ b/src/docker/DockerApi.ts
@@ -77,20 +77,33 @@ export function getLegacyServiceDnsAlias(
     return `srv-${namespace}--${serviceName}`
 }
 
+export interface IServiceNetworkAttachment {
+    Target: string
+    Aliases?: string[]
+    [key: string]: any
+}
+
 export function getServiceNetworkAttachments(
     networks: string[],
-    legacyDnsAlias: string | undefined
+    legacyDnsAlias: string | undefined,
+    existingAttachments: IServiceNetworkAttachment[] = []
 ) {
     return networks.map((network) => {
-        const attachment: {
-            Target: string
-            Aliases?: string[]
-        } = {
+        const existingAttachment = existingAttachments.find(
+            (attachment) => attachment.Target === network
+        )
+        const attachment: IServiceNetworkAttachment = {
+            ...existingAttachment,
             Target: network,
         }
 
         if (legacyDnsAlias) {
-            attachment.Aliases = [legacyDnsAlias]
+            attachment.Aliases = Array.from(
+                new Set([
+                    ...(existingAttachment?.Aliases || []),
+                    legacyDnsAlias,
+                ])
+            )
         }
 
         return attachment
@@ -1494,7 +1507,11 @@ class DockerApi {
                         : undefined
 
                     updatedData.TaskTemplate.Networks =
-                        getServiceNetworkAttachments(networks, legacyDnsAlias)
+                        getServiceNetworkAttachments(
+                            networks,
+                            legacyDnsAlias,
+                            updatedData.TaskTemplate.Networks || []
+                        )
                 }
 
                 if (secrets) {

--- a/src/docker/DockerApi.ts
+++ b/src/docker/DockerApi.ts
@@ -65,6 +65,38 @@ export abstract class IDockerUpdateOrders {
 }
 export type IDockerUpdateOrder = 'auto' | 'stopFirst' | 'startFirst'
 
+export function getLegacyServiceDnsAlias(
+    serviceName: string,
+    namespace: string | undefined,
+    isLegacyAppName: boolean
+) {
+    if (!namespace || isLegacyAppName) {
+        return undefined
+    }
+
+    return `srv-${namespace}--${serviceName}`
+}
+
+export function getServiceNetworkAttachments(
+    networks: string[],
+    legacyDnsAlias: string | undefined
+) {
+    return networks.map((network) => {
+        const attachment: {
+            Target: string
+            Aliases?: string[]
+        } = {
+            Target: network,
+        }
+
+        if (legacyDnsAlias) {
+            attachment.Aliases = [legacyDnsAlias]
+        }
+
+        return attachment
+    })
+}
+
 export interface CreateContainerParams {
     containerName?: string
     imageName: string
@@ -1453,12 +1485,16 @@ class DockerApi {
                 }
 
                 if (networks) {
-                    updatedData.TaskTemplate.Networks = []
-                    for (let i = 0; i < networks.length; i++) {
-                        updatedData.TaskTemplate.Networks.push({
-                            Target: networks[i],
-                        })
-                    }
+                    const legacyDnsAlias = appObject
+                        ? getLegacyServiceDnsAlias(
+                              serviceName,
+                              namespace,
+                              !!appObject.isLegacyAppName
+                          )
+                        : undefined
+
+                    updatedData.TaskTemplate.Networks =
+                        getServiceNetworkAttachments(networks, legacyDnsAlias)
                 }
 
                 if (secrets) {

--- a/src/handlers/users/apps/appdefinition/AppDefinitionHandler.ts
+++ b/src/handlers/users/apps/appdefinition/AppDefinitionHandler.ts
@@ -40,15 +40,15 @@ export async function registerAppDefinition(
             // if project is not found, it will throw an error
         }
 
-        // Avoid creating a DNS alias that conflicts with an orphaned legacy service
-        await serviceManager.ensureLegacyServiceNameAvailable(appName)
-
         // Register the app definition
         await dataStore
             .getAppsDataStore()
             .registerAppDefinition(appName, projectId, hasPersistentData)
 
         appCreated = true
+
+        // Avoid creating a DNS alias that conflicts with an orphaned legacy service
+        await serviceManager.ensureLegacyServiceNameAvailable(appName)
 
         // Create captain definition content
         const captainDefinitionContent: ICaptainDefinition = {

--- a/src/handlers/users/apps/appdefinition/AppDefinitionHandler.ts
+++ b/src/handlers/users/apps/appdefinition/AppDefinitionHandler.ts
@@ -47,9 +47,6 @@ export async function registerAppDefinition(
 
         appCreated = true
 
-        // Avoid creating a DNS alias that conflicts with an orphaned legacy service
-        await serviceManager.ensureLegacyServiceNameAvailable(appName)
-
         // Create captain definition content
         const captainDefinitionContent: ICaptainDefinition = {
             schemaVersion: 2,

--- a/src/handlers/users/apps/appdefinition/AppDefinitionHandler.ts
+++ b/src/handlers/users/apps/appdefinition/AppDefinitionHandler.ts
@@ -40,6 +40,9 @@ export async function registerAppDefinition(
             // if project is not found, it will throw an error
         }
 
+        // Avoid creating a DNS alias that conflicts with an orphaned legacy service
+        await serviceManager.ensureLegacyServiceNameAvailable(appName)
+
         // Register the app definition
         await dataStore
             .getAppsDataStore()

--- a/src/user/ServiceManager.ts
+++ b/src/user/ServiceManager.ts
@@ -419,6 +419,23 @@ class ServiceManager {
             })
     }
 
+    ensureLegacyServiceNameAvailable(appName: string) {
+        const legacyServiceName = this.dataStore
+            .getAppsDataStore()
+            .getServiceName(appName, true)
+
+        return this.dockerApi
+            .isServiceRunningByName(legacyServiceName)
+            .then(function (serviceExists) {
+                if (serviceExists) {
+                    throw ApiStatusCodes.createError(
+                        ApiStatusCodes.STATUS_ERROR_ALREADY_EXIST,
+                        `A Docker service named ${legacyServiceName} already exists and conflicts with the legacy DNS alias`
+                    )
+                }
+            })
+    }
+
     renameApp(oldAppName: string, newAppName: string) {
         Logger.d(`Renaming app: ${oldAppName}`)
         const self = this
@@ -441,6 +458,11 @@ class ServiceManager {
 
                 dataStore.getAppsDataStore().nameAllowedOrThrow(newAppName)
 
+                if (!appDef.isLegacyAppName) {
+                    return self.ensureLegacyServiceNameAvailable(newAppName)
+                }
+            })
+            .then(function () {
                 return self.ensureNotBuilding(oldAppName)
             })
             .then(function () {

--- a/src/user/ServiceManager.ts
+++ b/src/user/ServiceManager.ts
@@ -419,23 +419,6 @@ class ServiceManager {
             })
     }
 
-    ensureLegacyServiceNameAvailable(appName: string) {
-        const legacyServiceName = this.dataStore
-            .getAppsDataStore()
-            .getServiceName(appName, true)
-
-        return this.dockerApi
-            .isServiceRunningByName(legacyServiceName)
-            .then(function (serviceExists) {
-                if (serviceExists) {
-                    throw ApiStatusCodes.createError(
-                        ApiStatusCodes.STATUS_ERROR_ALREADY_EXIST,
-                        `A Docker service named ${legacyServiceName} already exists and conflicts with the legacy DNS alias`
-                    )
-                }
-            })
-    }
-
     renameApp(oldAppName: string, newAppName: string) {
         Logger.d(`Renaming app: ${oldAppName}`)
         const self = this
@@ -457,10 +440,6 @@ class ServiceManager {
                     .getServiceName(oldAppName, !!appDef.isLegacyAppName)
 
                 dataStore.getAppsDataStore().nameAllowedOrThrow(newAppName)
-
-                if (!appDef.isLegacyAppName) {
-                    return self.ensureLegacyServiceNameAvailable(newAppName)
-                }
             })
             .then(function () {
                 return self.ensureNotBuilding(oldAppName)

--- a/tests/ServiceNamingMigration.test.ts
+++ b/tests/ServiceNamingMigration.test.ts
@@ -166,26 +166,6 @@ describe('service and volume naming migration', () => {
         ])
     })
 
-    test('rejects a legacy DNS alias that conflicts with an orphaned service', async () => {
-        const serviceManager = Object.create(
-            ServiceManager.prototype
-        ) as ServiceManager
-        ;(serviceManager as any).dataStore = {
-            getAppsDataStore: () => ({
-                getServiceName: () => 'srv-captain--paperless-db',
-            }),
-        }
-        ;(serviceManager as any).dockerApi = {
-            isServiceRunningByName: jest.fn().mockResolvedValue(true),
-        }
-
-        await expect(
-            serviceManager.ensureLegacyServiceNameAvailable('paperless-db')
-        ).rejects.toThrow(
-            'A Docker service named srv-captain--paperless-db already exists'
-        )
-    })
-
     test('deletes both physical volumes when neither remains in use', async () => {
         const appsDataStore = new AppsDataStore(
             createConfigStore({}),

--- a/tests/ServiceNamingMigration.test.ts
+++ b/tests/ServiceNamingMigration.test.ts
@@ -116,6 +116,37 @@ describe('service and volume naming migration', () => {
         ])
     })
 
+    test('preserves existing aliases when rebuilding network attachments', () => {
+        expect(
+            getServiceNetworkAttachments(
+                ['network-a', 'network-b', 'network-c'],
+                undefined,
+                [
+                    {
+                        Target: 'network-a',
+                        Aliases: ['alias-a'],
+                    },
+                    {
+                        Target: 'network-b',
+                        Aliases: ['alias-b'],
+                    },
+                ]
+            )
+        ).toEqual([
+            {
+                Target: 'network-a',
+                Aliases: ['alias-a'],
+            },
+            {
+                Target: 'network-b',
+                Aliases: ['alias-b'],
+            },
+            {
+                Target: 'network-c',
+            },
+        ])
+    })
+
     test('does not add a redundant DNS alias to legacy apps', () => {
         const alias = getLegacyServiceDnsAlias(
             'srv-captain--paperless-db',

--- a/tests/ServiceNamingMigration.test.ts
+++ b/tests/ServiceNamingMigration.test.ts
@@ -3,6 +3,10 @@ import AppsDataStore, {
     isNameAllowed,
 } from '../src/datastore/AppsDataStore'
 import { runDataStoreMigrations } from '../src/datastore/DataStore'
+import {
+    getLegacyServiceDnsAlias,
+    getServiceNetworkAttachments,
+} from '../src/docker/DockerApi'
 import ServiceManager from '../src/user/ServiceManager'
 
 function createConfigStore(initialData: { [key: string]: any }) {
@@ -86,6 +90,69 @@ describe('service and volume naming migration', () => {
 
         expect(deleteVols).toHaveBeenCalledWith(['data'])
         expect(failedVolumes).toEqual(['data'])
+    })
+
+    test('adds the legacy DNS alias to every network for a new app', () => {
+        const alias = getLegacyServiceDnsAlias(
+            'paperless-db',
+            'captain',
+            false
+        )
+
+        expect(
+            getServiceNetworkAttachments(
+                ['captain-overlay-network', 'private-network'],
+                alias
+            )
+        ).toEqual([
+            {
+                Target: 'captain-overlay-network',
+                Aliases: ['srv-captain--paperless-db'],
+            },
+            {
+                Target: 'private-network',
+                Aliases: ['srv-captain--paperless-db'],
+            },
+        ])
+    })
+
+    test('does not add a redundant DNS alias to legacy apps', () => {
+        const alias = getLegacyServiceDnsAlias(
+            'srv-captain--paperless-db',
+            'captain',
+            true
+        )
+
+        expect(
+            getServiceNetworkAttachments(
+                ['captain-overlay-network'],
+                alias
+            )
+        ).toEqual([
+            {
+                Target: 'captain-overlay-network',
+            },
+        ])
+    })
+
+    test('rejects a legacy DNS alias that conflicts with an orphaned service', async () => {
+        const serviceManager = Object.create(
+            ServiceManager.prototype
+        ) as ServiceManager
+        ;(serviceManager as any).dataStore = {
+            getAppsDataStore: () => ({
+                getServiceName: () => 'srv-captain--paperless-db',
+            }),
+        }
+        ;(serviceManager as any).dockerApi = {
+            isServiceRunningByName: jest.fn().mockResolvedValue(true),
+        }
+
+        await expect(
+            serviceManager.ensureLegacyServiceNameAvailable('paperless-db')
+        ).rejects.toThrow(
+            'A Docker service named srv-captain--paperless-db already exists'
+        )
     })
 
     test('deletes both physical volumes when neither remains in use', async () => {


### PR DESCRIPTION
## What changed

- Adds `srv-captain--<appName>` as a network-scoped DNS alias for new app services while keeping the actual Docker service name unprefixed
- Leaves legacy app services unchanged because their physical service name already provides the legacy DNS name
- Leaves system-service updates such as `captain-captain` and `captain-nginx` on the original network-update path
- Recreates the compatibility alias whenever CapRover rebuilds a new app service's network attachments
- Adds focused tests for new apps, legacy apps, and multiple networks

## Why

This is stacked on #2328. Removing the physical `srv-captain--` prefix changes the DNS name of newly created services, but existing one-click and third-party templates commonly reference other services through names such as `srv-captain--myapp-db`. Without a compatibility alias, newly installed multi-service apps can no longer resolve those dependencies.

Docker Swarm network aliases preserve the established hostname without retaining the prefix in the actual service name.

## Impact

Existing migrated apps are unaffected. New apps resolve through both the new canonical service name and the legacy compatibility hostname on each attached network.

## Validation

- Added unit coverage for alias generation across multiple networks
- Added regression coverage confirming legacy apps receive no redundant alias
- No GitHub Actions run has been scheduled for this stacked PR because its base is the feature branch
- Build, lint, formatter, and tests must pass after the stack is rebased or retargeted
- A manual Docker Swarm DNS smoke test is still recommended before merging


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved service networking to support legacy DNS aliases during naming migrations.
  - New applications can remain reachable through compatible legacy service names across configured networks.

- **Bug Fixes**
  - Avoided adding redundant legacy aliases for applications already using legacy names.

- **Tests**
  - Added coverage for network aliases and legacy naming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->