### PR TITLE
Fix Netdata SMTP sender address

### DIFF
--- a/src/user/system/CaptainManager.ts
+++ b/src/user/system/CaptainManager.ts
@@ -576,7 +576,7 @@ class CaptainManager {
                     if (netDataInfo.data.smtp) {
                         envVars.push({
                             key: 'SMTP_FROM',
-                            value: netDataInfo.data.smtp.to,
+                            value: netDataInfo.data.smtp.username,
                         })
                         envVars.push({
                             key: 'SSMTP_TO',


### PR DESCRIPTION
## Summary

- use the configured SMTP username as Netdata's sender address
- keep the configured notification address exclusively as the recipient

## Root cause

CapRover set `SMTP_FROM` to `smtp.to`. SMTP servers that require the sender to match the authenticated account reject those notifications with a sender mismatch error.

The reporter manually tested `smtp.username` as `SMTP_FROM` and confirmed that notifications are delivered successfully.

Fixes #2261

## Validation

- verified the branch is one commit ahead of `master`
- verified the diff contains only the `SMTP_FROM` mapping change
- reporter confirmed the same environment-variable change against the affected SMTP server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the sender address used for Netdata email notifications, ensuring SMTP configuration uses the appropriate account information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->