### PR TITLE
Add CapRover label to managed Docker services

### DIFF
--- a/src/docker/DockerApi.ts
+++ b/src/docker/DockerApi.ts
@@ -28,6 +28,7 @@ import Dockerode = require('dockerode')
 import dockerodeUtils = require('dockerode/lib/util')
 
 const Base64 = Base64Provider.Base64
+const CAPROVER_MANAGED_SERVICE_LABEL = 'com.caprover.managed'
 
 function safeParseChunk(chunk: string): {
     stream?: string
@@ -867,6 +868,9 @@ class DockerApi {
 
         const dataToCreate: any = {
             name: serviceName,
+            Labels: {
+                [CAPROVER_MANAGED_SERVICE_LABEL]: 'true',
+            },
             TaskTemplate: {
                 ContainerSpec: {
                     Image: imageName,

--- a/src/docker/DockerApi.ts
+++ b/src/docker/DockerApi.ts
@@ -1655,6 +1655,9 @@ class DockerApi {
                 return updatedData
             })
             .then(function (updatedData) {
+                updatedData.Labels = updatedData.Labels || {}
+                updatedData.Labels[CAPROVER_MANAGED_SERVICE_LABEL] = 'true'
+
                 return self.dockerode
                     .getService(serviceName)
                     .update(updatedData)


### PR DESCRIPTION
## What changed

- Add the service-level label `com.caprover.managed=true` to every Docker service created through `createServiceOnNodeId()`.
- Ensure the same label is present whenever CapRover updates a service, while preserving any existing service labels.

## Why

After removing the `srv-captain--` prefix for new apps in #2328, users need a standard way to distinguish CapRover-managed services from unrelated Docker services. Docker service labels provide that identifier and support filtering with:

```bash
docker service ls --filter label=com.caprover.managed=true
```

There is no bulk backfill. Existing legacy services remain identifiable by their `srv-captain--` prefix and receive the label only if CapRover naturally updates them later.

## Validation

- `npm run formatter`
- `npm run lint`
- `npm run build`