### PR TITLE
Expose and protect legacy app name flag

### DIFF
--- a/src/datastore/AppsDataStore.ts
+++ b/src/datastore/AppsDataStore.ts
@@ -94,6 +94,18 @@ class AppsDataStore {
                     )
                 }
 
+                const existingApp = self.data.get(
+                    `${APP_DEFINITIONS}.${appName}`
+                ) as IAppDefSaved | undefined
+
+                if (existingApp) {
+                    if (existingApp.isLegacyAppName === undefined) {
+                        delete app.isLegacyAppName
+                    } else {
+                        app.isLegacyAppName = existingApp.isLegacyAppName
+                    }
+                }
+
                 if (app.forceSsl) {
                     let hasAtLeastOneSslDomain = app.hasDefaultSubDomainSsl
                     const customDomainArray = app.customDomain

--- a/src/handlers/users/apps/appdefinition/AppDefinitionHandler.ts
+++ b/src/handlers/users/apps/appdefinition/AppDefinitionHandler.ts
@@ -116,6 +116,7 @@ export async function getAllAppDefinitions(
             const app = apps[key]
             app.appName = key
             app.isAppBuilding = serviceManager.isAppBuilding(key)
+            app.isLegacyAppName = !!app.isLegacyAppName
             app.appPushWebhook = app.appPushWebhook || undefined
             appsArray.push(app)
         })

--- a/tests/ServiceNamingMigration.test.ts
+++ b/tests/ServiceNamingMigration.test.ts
@@ -3,6 +3,8 @@ import AppsDataStore, {
     isNameAllowed,
 } from '../src/datastore/AppsDataStore'
 import { runDataStoreMigrations } from '../src/datastore/DataStore'
+import { getAllAppDefinitions } from '../src/handlers/users/apps/appdefinition/AppDefinitionHandler'
+import { IAppDef } from '../src/models/AppDefinition'
 import {
     getLegacyServiceDnsAlias,
     getServiceNetworkAttachments,
@@ -17,6 +19,27 @@ function createConfigStore(initialData: { [key: string]: any }) {
             data[key] = value
         }),
     } as unknown as configstore
+}
+
+function createAppDefinition(overrides: Partial<IAppDef> = {}): IAppDef {
+    return {
+        description: '',
+        deployedVersion: 0,
+        notExposeAsWebApp: false,
+        hasPersistentData: false,
+        hasDefaultSubDomainSsl: false,
+        captainDefinitionRelativeFilePath: './captain-definition',
+        forceSsl: false,
+        websocketSupport: false,
+        instanceCount: 1,
+        networks: ['captain-overlay-network'],
+        customDomain: [],
+        ports: [],
+        volumes: [],
+        envVars: [],
+        versions: [],
+        ...overrides,
+    }
 }
 
 describe('service and volume naming migration', () => {
@@ -47,6 +70,87 @@ describe('service and volume naming migration', () => {
 
         expect(appDefinitions.newApp).toEqual({})
         expect(data.set).not.toHaveBeenCalled()
+    })
+
+    test('returns an explicit legacy app name flag for every app', async () => {
+        const dataStore = {
+            getAppsDataStore: () => ({
+                getAppDefinitions: jest.fn().mockResolvedValue({
+                    legacyApp: createAppDefinition({
+                        isLegacyAppName: true,
+                    }),
+                    modernApp: createAppDefinition(),
+                }),
+            }),
+            getDefaultAppNginxConfig: jest.fn().mockResolvedValue(''),
+            getRootDomain: jest.fn().mockReturnValue('example.com'),
+        } as any
+        const serviceManager = {
+            isAppBuilding: jest.fn().mockReturnValue(false),
+        } as any
+
+        const result = await getAllAppDefinitions(dataStore, serviceManager)
+
+        expect(result.data.appDefinitions).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    appName: 'legacyApp',
+                    isLegacyAppName: true,
+                }),
+                expect.objectContaining({
+                    appName: 'modernApp',
+                    isLegacyAppName: false,
+                }),
+            ])
+        )
+    })
+
+    test('does not let saves override the legacy app name flag', async () => {
+        const storedApp = createAppDefinition({ isLegacyAppName: true })
+        const data = {
+            get: jest.fn((key: string) => {
+                if (key === 'appDefinitions.legacy-app') {
+                    return storedApp
+                }
+                return undefined
+            }),
+            set: jest.fn(),
+        } as unknown as configstore
+        const appsDataStore = new AppsDataStore(data, 'captain')
+
+        await (appsDataStore as any).saveApp(
+            'legacy-app',
+            createAppDefinition({ isLegacyAppName: false })
+        )
+
+        expect(data.set).toHaveBeenCalledWith(
+            'appDefinitions.legacy-app',
+            expect.objectContaining({ isLegacyAppName: true })
+        )
+    })
+
+    test('does not let saves mark a modern app as legacy', async () => {
+        const storedApp = createAppDefinition()
+        const data = {
+            get: jest.fn((key: string) => {
+                if (key === 'appDefinitions.modern-app') {
+                    return storedApp
+                }
+                return undefined
+            }),
+            set: jest.fn(),
+        } as unknown as configstore
+        const appsDataStore = new AppsDataStore(data, 'captain')
+
+        await (appsDataStore as any).saveApp(
+            'modern-app',
+            createAppDefinition({ isLegacyAppName: true })
+        )
+
+        expect(data.set).toHaveBeenCalledWith(
+            'appDefinitions.modern-app',
+            expect.not.objectContaining({ isLegacyAppName: expect.anything() })
+        )
     })
 
     test('reserves the captain service-name prefix', () => {


### PR DESCRIPTION
## What changed

- Return `isLegacyAppName` as an explicit boolean for every app definition in the apps response, including `false` for modern apps.
- Preserve the persisted `isLegacyAppName` value at the datastore save boundary so update paths cannot flip, add, or remove it.
- Add regression coverage for API serialization and both override directions.

## Why

The marker is server-owned migration metadata. Modern apps previously omitted it from JSON because their stored value is undefined, and relying only on current update parameter whitelists was not strong enough to guarantee immutability across future write paths.

The frontend uses the same apps response for both the app list and a selected app's details, so both consumers now receive the explicit flag.

## Validation

- `npm test -- --runInBand --forceExit tests/ServiceNamingMigration.test.ts tests/PatchAppDefinition.test.ts` (18 tests passed)
- `npm run build`
- `npm run lint`
- Prettier check and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved legacy app-name status when app definitions are updated.
  * Prevented updates from incorrectly changing an app between legacy and modern naming.
  * Ensured app definitions consistently return a clear true/false legacy-name status.

* **Tests**
  * Added coverage for legacy and modern app-name behavior during retrieval and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->