### PR TITLE
feat(api): add GET /user/system/volumes for named volume inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Next Version - available as `edge`]
 
+- New: Authorized API to list Docker named volumes (`GET /user/system/volumes/`) with app usage enrichment for Persistent Directories conflict detection
 - New: Ability to deploy simplified Docker compose [PR-191](https://github.com/caprover/caprover-frontend/pull/191)
 - New: Defaulting to BuildKit [Issue-1582](https://github.com/caprover/caprover/issues/1582)
 - New: Defaulting to gzip on [PR-2360](https://github.com/caprover/caprover/pull/2360)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Next Version - available as `edge`]
 
-- New: Authorized API to list Docker named volumes (`GET /user/system/volumes/`) with app usage enrichment for Persistent Directories conflict detection
+- New: Authorized API to list CapRover-managed named volumes configured through Persistent Directories (`GET /user/system/volumes/`)
 - New: Ability to deploy simplified Docker compose [PR-191](https://github.com/caprover/caprover-frontend/pull/191)
 - New: Defaulting to BuildKit [Issue-1582](https://github.com/caprover/caprover/issues/1582)
 - New: Defaulting to gzip on [PR-2360](https://github.com/caprover/caprover/pull/2360)

--- a/dev-scripts/CapRover_Postman_Collection.json
+++ b/dev-scripts/CapRover_Postman_Collection.json
@@ -483,6 +483,32 @@
       "response": []
     },
     {
+      "name": "GET volumes",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "x-captain-auth",
+            "value": "{{captain_auth_token}}"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "x-namespace",
+            "value": "captain"
+          }
+        ],
+        "url": {
+          "raw": "{{baseUrl}}/user/system/volumes/",
+          "host": ["{{baseUrl}}"],
+          "path": ["user", "system", "volumes", ""]
+        }
+      },
+      "response": []
+    },
+    {
       "name": "Create Backup",
       "request": {
         "method": "POST",

--- a/src/docker/DockerApi.ts
+++ b/src/docker/DockerApi.ts
@@ -100,6 +100,64 @@ export function getServiceNetworkAttachments(
     })
 }
 
+/**
+ * Docker Engine may return CreatedAt on volume inspect/list even though
+ * @types/dockerode VolumeInspectInfo omits it.
+ */
+export type VolumeInspectWithCreatedAt = Dockerode.VolumeInspectInfo & {
+    CreatedAt?: string
+}
+
+/**
+ * CamelCase DTO for Docker named volumes (node-local to CapRover's engine).
+ * size/refCount are rarely present on listVolumes and must not be required by clients.
+ */
+export interface DockerVolumeInfo {
+    name: string
+    driver: string
+    mountpoint: string
+    scope: 'local' | 'global' | string
+    /** Always an object; Docker null/undefined Labels mapped to {} */
+    labels: { [key: string]: string }
+    /** Prefer Docker's null when Options are null; do not coerce to {} */
+    options: { [key: string]: string } | null
+    /**
+     * Almost always absent for listVolumes().
+     * Docker documents UsageData primarily for GET /system/df.
+     * Do NOT use for conflict logic. Mapped only if present.
+     */
+    size?: number
+    refCount?: number
+    /** Optional; Engine often returns CreatedAt though types omit it */
+    createdAt?: string
+}
+
+/** Pure mapper — unit-test without DockerApi singleton */
+export function mapVolumeInspectToDto(
+    v: VolumeInspectWithCreatedAt
+): DockerVolumeInfo {
+    const dto: DockerVolumeInfo = {
+        name: v.Name,
+        driver: v.Driver,
+        mountpoint: v.Mountpoint,
+        scope: v.Scope,
+        labels: v.Labels || {},
+        options: v.Options,
+    }
+
+    if (v.UsageData && typeof v.UsageData.Size === 'number') {
+        dto.size = v.UsageData.Size
+    }
+    if (v.UsageData && typeof v.UsageData.RefCount === 'number') {
+        dto.refCount = v.UsageData.RefCount
+    }
+    if (v.CreatedAt) {
+        dto.createdAt = v.CreatedAt
+    }
+
+    return dto
+}
+
 export interface CreateContainerParams {
     containerName?: string
     imageName: string
@@ -1784,6 +1842,36 @@ class DockerApi {
         return Promise.resolve().then(function () {
             return self.dockerode.listImages()
         })
+    }
+
+    /**
+     * List named volumes visible on CapRover's Docker engine endpoint only
+     * (node-local; not swarm-global). Empty Volumes maps to [].
+     * Failures reject and must not be treated as an empty success list by callers.
+     */
+    getVolumes(): Promise<DockerVolumeInfo[]> {
+        const self = this
+
+        return Promise.resolve()
+            .then(function () {
+                return self.dockerode.listVolumes()
+            })
+            .then(function (result) {
+                const warnings = (result && result.Warnings) || []
+                if (warnings.length) {
+                    Logger.w(
+                        'Docker listVolumes warnings: ' + warnings.join(' | ')
+                    )
+                }
+
+                // Success with empty/missing Volumes → []; do NOT treat as error
+                const volumes = (result && result.Volumes) || []
+                return volumes.map(function (v) {
+                    return mapVolumeInspectToDto(
+                        v as VolumeInspectWithCreatedAt
+                    )
+                })
+            })
     }
 
     getNodeLables(nodeId: string) {

--- a/src/docker/DockerApi.ts
+++ b/src/docker/DockerApi.ts
@@ -100,64 +100,6 @@ export function getServiceNetworkAttachments(
     })
 }
 
-/**
- * Docker Engine may return CreatedAt on volume inspect/list even though
- * @types/dockerode VolumeInspectInfo omits it.
- */
-export type VolumeInspectWithCreatedAt = Dockerode.VolumeInspectInfo & {
-    CreatedAt?: string
-}
-
-/**
- * CamelCase DTO for Docker named volumes (node-local to CapRover's engine).
- * size/refCount are rarely present on listVolumes and must not be required by clients.
- */
-export interface DockerVolumeInfo {
-    name: string
-    driver: string
-    mountpoint: string
-    scope: 'local' | 'global' | string
-    /** Always an object; Docker null/undefined Labels mapped to {} */
-    labels: { [key: string]: string }
-    /** Prefer Docker's null when Options are null; do not coerce to {} */
-    options: { [key: string]: string } | null
-    /**
-     * Almost always absent for listVolumes().
-     * Docker documents UsageData primarily for GET /system/df.
-     * Do NOT use for conflict logic. Mapped only if present.
-     */
-    size?: number
-    refCount?: number
-    /** Optional; Engine often returns CreatedAt though types omit it */
-    createdAt?: string
-}
-
-/** Pure mapper — unit-test without DockerApi singleton */
-export function mapVolumeInspectToDto(
-    v: VolumeInspectWithCreatedAt
-): DockerVolumeInfo {
-    const dto: DockerVolumeInfo = {
-        name: v.Name,
-        driver: v.Driver,
-        mountpoint: v.Mountpoint,
-        scope: v.Scope,
-        labels: v.Labels || {},
-        options: v.Options,
-    }
-
-    if (v.UsageData && typeof v.UsageData.Size === 'number') {
-        dto.size = v.UsageData.Size
-    }
-    if (v.UsageData && typeof v.UsageData.RefCount === 'number') {
-        dto.refCount = v.UsageData.RefCount
-    }
-    if (v.CreatedAt) {
-        dto.createdAt = v.CreatedAt
-    }
-
-    return dto
-}
-
 export interface CreateContainerParams {
     containerName?: string
     imageName: string
@@ -1842,36 +1784,6 @@ class DockerApi {
         return Promise.resolve().then(function () {
             return self.dockerode.listImages()
         })
-    }
-
-    /**
-     * List named volumes visible on CapRover's Docker engine endpoint only
-     * (node-local; not swarm-global). Empty Volumes maps to [].
-     * Failures reject and must not be treated as an empty success list by callers.
-     */
-    getVolumes(): Promise<DockerVolumeInfo[]> {
-        const self = this
-
-        return Promise.resolve()
-            .then(function () {
-                return self.dockerode.listVolumes()
-            })
-            .then(function (result) {
-                const warnings = (result && result.Warnings) || []
-                if (warnings.length) {
-                    Logger.w(
-                        'Docker listVolumes warnings: ' + warnings.join(' | ')
-                    )
-                }
-
-                // Success with empty/missing Volumes → []; do NOT treat as error
-                const volumes = (result && result.Volumes) || []
-                return volumes.map(function (v) {
-                    return mapVolumeInspectToDto(
-                        v as VolumeInspectWithCreatedAt
-                    )
-                })
-            })
     }
 
     getNodeLables(nodeId: string) {

--- a/src/handlers/users/system/VolumesHandler.ts
+++ b/src/handlers/users/system/VolumesHandler.ts
@@ -1,0 +1,130 @@
+import DataStore from '../../../datastore/DataStore'
+import { DockerVolumeInfo } from '../../../docker/DockerApi'
+import { IAllAppDefinitions } from '../../../models/AppDefinition'
+import CaptainConstants from '../../../utils/CaptainConstants'
+import Logger from '../../../utils/Logger'
+
+export interface VolumeListItem extends DockerVolumeInfo {
+    /**
+     * CapRover apps whose named Persistent Directories (IAppVolume.volumeName)
+     * resolve to this physical Docker volume name via getVolumeName.
+     * Always present (may be []). Bind-only Persistent Directories are ignored.
+     */
+    usedByAppNames: string[]
+    /**
+     * Heuristic: name looks CapRover-platform / reserved.
+     * Always present. NOT a security boundary — UX copy only.
+     */
+    isLikelySystem: boolean
+}
+
+/**
+ * Heuristic only — NOT ownership proof or access control.
+ *
+ * Matches reserved app names (captain, registry), namespace-prefixed platform
+ * names (captain-nginx, legacy captain--*), and known CapRover service names.
+ *
+ * Caveat: legacy user volumes (`captain--*`) also match the prefix rule.
+ * Prefer usedByAppNames for share/orphan logic; use isLikelySystem only for
+ * softer wording when the name looks platform-ish.
+ */
+export function isLikelySystemVolumeName(
+    physicalName: string,
+    namespace: string = CaptainConstants.rootNameSpace
+): boolean {
+    const name = (physicalName || '').toLowerCase()
+    const ns = (namespace || CaptainConstants.rootNameSpace).toLowerCase()
+
+    if (!name) {
+        return false
+    }
+
+    // Reserved exact names (same set blocked for app names in isNameAllowed)
+    if (name === ns || name === 'registry') {
+        return true
+    }
+
+    // Platform / service prefix: captain-nginx, captain-certbot, ...
+    // Also matches legacy physical prefix captain--* (captain-- starts with captain-)
+    if (name.startsWith(ns + '-')) {
+        return true
+    }
+
+    // Explicit known CapRover Docker object names (defense in depth)
+    const knownSystemNames = [
+        CaptainConstants.nginxServiceName,
+        CaptainConstants.captainServiceName,
+        CaptainConstants.certbotServiceName,
+        CaptainConstants.registryServiceName,
+        CaptainConstants.goAccessContainerName,
+        CaptainConstants.netDataContainerName,
+    ].map((n) => n.toLowerCase())
+
+    if (knownSystemNames.indexOf(name) >= 0) {
+        return true
+    }
+
+    return false
+}
+
+/**
+ * Join Docker physical volume names to CapRover apps via named Persistent
+ * Directories only (skip bind-style hostPath entries).
+ */
+export function enrichVolumesWithAppUsage(
+    volumes: DockerVolumeInfo[],
+    apps: IAllAppDefinitions,
+    dataStore: DataStore,
+    namespace: string = CaptainConstants.rootNameSpace
+): VolumeListItem[] {
+    const physicalToApps: { [physicalName: string]: string[] } = {}
+    const appsStore = dataStore.getAppsDataStore()
+
+    Object.keys(apps).forEach((appName) => {
+        const app = apps[appName]
+        ;(app.volumes || []).forEach((vol) => {
+            // Named Persistent Directory only; skip bind-style hostPath entries
+            if (!vol.volumeName) {
+                return
+            }
+
+            const physical = appsStore.getVolumeName(
+                vol.volumeName,
+                !!app.isLegacyAppName
+            )
+
+            if (!physicalToApps[physical]) {
+                physicalToApps[physical] = []
+            }
+
+            if (physicalToApps[physical].indexOf(appName) < 0) {
+                physicalToApps[physical].push(appName)
+            }
+        })
+    })
+
+    Logger.d(
+        `Volume enrichment: ${Object.keys(physicalToApps).length} physical names referenced by apps`
+    )
+
+    return volumes.map((v) => ({
+        ...v,
+        usedByAppNames: physicalToApps[v.name] || [],
+        isLikelySystem: isLikelySystemVolumeName(v.name, namespace),
+    }))
+}
+
+/** Stable ascending sort by physical volume name (API contract). */
+export function sortVolumesByName(
+    volumes: VolumeListItem[]
+): VolumeListItem[] {
+    return volumes.slice().sort(function (a, b) {
+        if (a.name < b.name) {
+            return -1
+        }
+        if (a.name > b.name) {
+            return 1
+        }
+        return 0
+    })
+}

--- a/src/handlers/users/system/VolumesHandler.ts
+++ b/src/handlers/users/system/VolumesHandler.ts
@@ -115,9 +115,7 @@ export function enrichVolumesWithAppUsage(
 }
 
 /** Stable ascending sort by physical volume name (API contract). */
-export function sortVolumesByName(
-    volumes: VolumeListItem[]
-): VolumeListItem[] {
+export function sortVolumesByName(volumes: VolumeListItem[]): VolumeListItem[] {
     return volumes.slice().sort(function (a, b) {
         if (a.name < b.name) {
             return -1

--- a/src/handlers/users/system/VolumesHandler.ts
+++ b/src/handlers/users/system/VolumesHandler.ts
@@ -1,128 +1,56 @@
 import DataStore from '../../../datastore/DataStore'
-import { DockerVolumeInfo } from '../../../docker/DockerApi'
 import { IAllAppDefinitions } from '../../../models/AppDefinition'
-import CaptainConstants from '../../../utils/CaptainConstants'
 import Logger from '../../../utils/Logger'
 
-export interface VolumeListItem extends DockerVolumeInfo {
-    /**
-     * CapRover apps whose named Persistent Directories (IAppVolume.volumeName)
-     * resolve to this physical Docker volume name via getVolumeName.
-     * Always present (may be []). Bind-only Persistent Directories are ignored.
-     */
+export interface VolumeListItem {
+    name: string
     usedByAppNames: string[]
-    /**
-     * Heuristic: name looks CapRover-platform / reserved.
-     * Always present. NOT a security boundary — UX copy only.
-     */
-    isLikelySystem: boolean
 }
 
 /**
- * Heuristic only — NOT ownership proof or access control.
- *
- * Matches reserved app names (captain, registry), namespace-prefixed platform
- * names (captain-nginx, legacy captain--*), and known CapRover service names.
- *
- * Caveat: legacy user volumes (`captain--*`) also match the prefix rule.
- * Prefer usedByAppNames for share/orphan logic; use isLikelySystem only for
- * softer wording when the name looks platform-ish.
+ * Builds the CapRover-managed named-volume inventory from configured Persistent
+ * Directories. Bind-style hostPath entries are deliberately excluded.
  */
-export function isLikelySystemVolumeName(
-    physicalName: string,
-    namespace: string = CaptainConstants.rootNameSpace
-): boolean {
-    const name = (physicalName || '').toLowerCase()
-    const ns = (namespace || CaptainConstants.rootNameSpace).toLowerCase()
-
-    if (!name) {
-        return false
-    }
-
-    // Reserved exact names (same set blocked for app names in isNameAllowed)
-    if (name === ns || name === 'registry') {
-        return true
-    }
-
-    // Platform / service prefix: captain-nginx, captain-certbot, ...
-    // Also matches legacy physical prefix captain--* (captain-- starts with captain-)
-    if (name.startsWith(ns + '-')) {
-        return true
-    }
-
-    // Explicit known CapRover Docker object names (defense in depth)
-    const knownSystemNames = [
-        CaptainConstants.nginxServiceName,
-        CaptainConstants.captainServiceName,
-        CaptainConstants.certbotServiceName,
-        CaptainConstants.registryServiceName,
-        CaptainConstants.goAccessContainerName,
-        CaptainConstants.netDataContainerName,
-    ].map((n) => n.toLowerCase())
-
-    if (knownSystemNames.indexOf(name) >= 0) {
-        return true
-    }
-
-    return false
-}
-
-/**
- * Join Docker physical volume names to CapRover apps via named Persistent
- * Directories only (skip bind-style hostPath entries).
- */
-export function enrichVolumesWithAppUsage(
-    volumes: DockerVolumeInfo[],
+export function getManagedVolumes(
     apps: IAllAppDefinitions,
-    dataStore: DataStore,
-    namespace: string = CaptainConstants.rootNameSpace
+    dataStore: DataStore
 ): VolumeListItem[] {
-    const physicalToApps: { [physicalName: string]: string[] } = {}
+    const usedByAppNamesByVolume: { [volumeName: string]: string[] } = {}
     const appsStore = dataStore.getAppsDataStore()
 
     Object.keys(apps).forEach((appName) => {
         const app = apps[appName]
         ;(app.volumes || []).forEach((vol) => {
-            // Named Persistent Directory only; skip bind-style hostPath entries
             if (!vol.volumeName) {
                 return
             }
 
-            const physical = appsStore.getVolumeName(
+            const physicalVolumeName = appsStore.getVolumeName(
                 vol.volumeName,
                 !!app.isLegacyAppName
             )
 
-            if (!physicalToApps[physical]) {
-                physicalToApps[physical] = []
+            if (!usedByAppNamesByVolume[physicalVolumeName]) {
+                usedByAppNamesByVolume[physicalVolumeName] = []
             }
 
-            if (physicalToApps[physical].indexOf(appName) < 0) {
-                physicalToApps[physical].push(appName)
+            const usedByAppNames = usedByAppNamesByVolume[physicalVolumeName]
+            if (usedByAppNames.indexOf(appName) < 0) {
+                usedByAppNames.push(appName)
             }
         })
     })
 
+    const volumes = Object.keys(usedByAppNamesByVolume)
+        .sort()
+        .map((name) => ({
+            name,
+            usedByAppNames: usedByAppNamesByVolume[name].slice().sort(),
+        }))
+
     Logger.d(
-        `Volume enrichment: ${Object.keys(physicalToApps).length} physical names referenced by apps`
+        `Managed volume list built from ${Object.keys(apps).length} app definitions: ${volumes.length} volumes`
     )
 
-    return volumes.map((v) => ({
-        ...v,
-        usedByAppNames: physicalToApps[v.name] || [],
-        isLikelySystem: isLikelySystemVolumeName(v.name, namespace),
-    }))
-}
-
-/** Stable ascending sort by physical volume name (API contract). */
-export function sortVolumesByName(volumes: VolumeListItem[]): VolumeListItem[] {
-    return volumes.slice().sort(function (a, b) {
-        if (a.name < b.name) {
-            return -1
-        }
-        if (a.name > b.name) {
-            return 1
-        }
-        return 0
-    })
+    return volumes
 }

--- a/src/routes/user/system/SystemRouter.ts
+++ b/src/routes/user/system/SystemRouter.ts
@@ -6,6 +6,10 @@ import ApiStatusCodes from '../../../api/ApiStatusCodes'
 import BaseApi from '../../../api/BaseApi'
 import DockerApi from '../../../docker/DockerApi'
 import DockerUtils from '../../../docker/DockerUtils'
+import {
+    enrichVolumesWithAppUsage,
+    sortVolumesByName,
+} from '../../../handlers/users/system/VolumesHandler'
 import InjectionExtractor from '../../../injection/InjectionExtractor'
 import { IAppDef } from '../../../models/AppDefinition'
 import { AutomatedCleanupConfigsCleaner } from '../../../models/AutomatedCleanupConfigs'
@@ -551,6 +555,46 @@ router.get('/nodes/', function (req, res, next) {
                 'Node info retrieved'
             )
             baseApi.data = { nodes: data }
+            res.send(baseApi)
+        })
+        .catch(ApiStatusCodes.createCatcher(res))
+})
+
+/**
+ * List Docker named volumes on CapRover's Docker engine endpoint (node-local).
+ * Enriched with usedByAppNames for Persistent Directories conflict detection.
+ * Auth: UserRouter injectUser (x-captain-auth). GET only — no write lock.
+ */
+router.get('/volumes/', function (req, res, next) {
+    const injectedUser = InjectionExtractor.extractUserFromInjected(res).user
+    const dataStore = injectedUser.dataStore
+    const namespace = injectedUser.namespace || CaptainConstants.rootNameSpace
+
+    return Promise.resolve()
+        .then(function () {
+            return DockerApi.get().getVolumes()
+        })
+        .then(function (volumes) {
+            return dataStore
+                .getAppsDataStore()
+                .getAppDefinitions()
+                .then(function (apps) {
+                    return enrichVolumesWithAppUsage(
+                        volumes,
+                        apps,
+                        dataStore,
+                        namespace
+                    )
+                })
+        })
+        .then(function (volumes) {
+            const sorted = sortVolumesByName(volumes)
+            Logger.d('Volumes retrieved: ' + sorted.length)
+            const baseApi = new BaseApi(
+                ApiStatusCodes.STATUS_OK,
+                'Volumes retrieved'
+            )
+            baseApi.data = { volumes: sorted }
             res.send(baseApi)
         })
         .catch(ApiStatusCodes.createCatcher(res))

--- a/src/routes/user/system/SystemRouter.ts
+++ b/src/routes/user/system/SystemRouter.ts
@@ -6,10 +6,7 @@ import ApiStatusCodes from '../../../api/ApiStatusCodes'
 import BaseApi from '../../../api/BaseApi'
 import DockerApi from '../../../docker/DockerApi'
 import DockerUtils from '../../../docker/DockerUtils'
-import {
-    enrichVolumesWithAppUsage,
-    sortVolumesByName,
-} from '../../../handlers/users/system/VolumesHandler'
+import { getManagedVolumes } from '../../../handlers/users/system/VolumesHandler'
 import InjectionExtractor from '../../../injection/InjectionExtractor'
 import { IAppDef } from '../../../models/AppDefinition'
 import { AutomatedCleanupConfigsCleaner } from '../../../models/AutomatedCleanupConfigs'
@@ -561,40 +558,29 @@ router.get('/nodes/', function (req, res, next) {
 })
 
 /**
- * List Docker named volumes on CapRover's Docker engine endpoint (node-local).
- * Enriched with usedByAppNames for Persistent Directories conflict detection.
+ * List CapRover-managed named volumes configured by app Persistent Directories.
  * Auth: UserRouter injectUser (x-captain-auth). GET only — no write lock.
  */
 router.get('/volumes/', function (req, res, next) {
     const injectedUser = InjectionExtractor.extractUserFromInjected(res).user
     const dataStore = injectedUser.dataStore
-    const namespace = injectedUser.namespace || CaptainConstants.rootNameSpace
 
     return Promise.resolve()
         .then(function () {
-            return DockerApi.get().getVolumes()
-        })
-        .then(function (volumes) {
             return dataStore
                 .getAppsDataStore()
                 .getAppDefinitions()
                 .then(function (apps) {
-                    return enrichVolumesWithAppUsage(
-                        volumes,
-                        apps,
-                        dataStore,
-                        namespace
-                    )
+                    return getManagedVolumes(apps, dataStore)
                 })
         })
         .then(function (volumes) {
-            const sorted = sortVolumesByName(volumes)
-            Logger.d('Volumes retrieved: ' + sorted.length)
+            Logger.d('Managed volumes retrieved: ' + volumes.length)
             const baseApi = new BaseApi(
                 ApiStatusCodes.STATUS_OK,
                 'Volumes retrieved'
             )
-            baseApi.data = { volumes: sorted }
+            baseApi.data = { volumes }
             res.send(baseApi)
         })
         .catch(ApiStatusCodes.createCatcher(res))

--- a/tests/VolumesList.test.ts
+++ b/tests/VolumesList.test.ts
@@ -1,14 +1,4 @@
-import {
-    DockerVolumeInfo,
-    mapVolumeInspectToDto,
-    VolumeInspectWithCreatedAt,
-} from '../src/docker/DockerApi'
-import {
-    enrichVolumesWithAppUsage,
-    isLikelySystemVolumeName,
-    sortVolumesByName,
-    VolumeListItem,
-} from '../src/handlers/users/system/VolumesHandler'
+import { getManagedVolumes } from '../src/handlers/users/system/VolumesHandler'
 import { IAllAppDefinitions, IAppDef } from '../src/models/AppDefinition'
 
 function createAppDefinition(overrides: Partial<IAppDef> = {}): IAppDef {
@@ -39,288 +29,105 @@ function createMockDataStore(namespace: string = 'captain') {
                 if (isLegacy) {
                     return `${namespace}--${volumeName}`
                 }
+
                 return volumeName
             },
         }),
     } as any
 }
 
-function baseVolume(
-    overrides: Partial<DockerVolumeInfo> = {}
-): DockerVolumeInfo {
-    return {
-        name: 'my-data',
-        driver: 'local',
-        mountpoint: '/var/lib/docker/volumes/my-data/_data',
-        scope: 'local',
-        labels: {},
-        options: null,
-        ...overrides,
-    }
-}
-
-describe('mapVolumeInspectToDto', () => {
-    test('maps required fields and coerces null Labels to {}', () => {
-        const inspect = {
-            Name: 'vol-a',
-            Driver: 'local',
-            Mountpoint: '/var/lib/docker/volumes/vol-a/_data',
-            Scope: 'local',
-            Labels: null,
-            Options: null,
-        } as unknown as VolumeInspectWithCreatedAt
-
-        expect(mapVolumeInspectToDto(inspect)).toEqual({
-            name: 'vol-a',
-            driver: 'local',
-            mountpoint: '/var/lib/docker/volumes/vol-a/_data',
-            scope: 'local',
-            labels: {},
-            options: null,
-        })
-    })
-
-    test('maps UsageData and CreatedAt only when present', () => {
-        const inspect = {
-            Name: 'vol-b',
-            Driver: 'local',
-            Mountpoint: '/mp',
-            Scope: 'local',
-            Labels: { a: 'b' },
-            Options: { device: 'tmpfs' },
-            UsageData: { Size: 1024, RefCount: 2 },
-            CreatedAt: '2024-01-15T12:34:56Z',
-        } as VolumeInspectWithCreatedAt
-
-        expect(mapVolumeInspectToDto(inspect)).toEqual({
-            name: 'vol-b',
-            driver: 'local',
-            mountpoint: '/mp',
-            scope: 'local',
-            labels: { a: 'b' },
-            options: { device: 'tmpfs' },
-            size: 1024,
-            refCount: 2,
-            createdAt: '2024-01-15T12:34:56Z',
-        })
-    })
-
-    test('omits size/refCount when UsageData is missing (typical listVolumes)', () => {
-        const inspect = {
-            Name: 'vol-c',
-            Driver: 'local',
-            Mountpoint: '/mp',
-            Scope: 'local',
-            Labels: {},
-            Options: null,
-        } as VolumeInspectWithCreatedAt
-
-        const dto = mapVolumeInspectToDto(inspect)
-        expect(dto.size).toBeUndefined()
-        expect(dto.refCount).toBeUndefined()
-        expect(dto.createdAt).toBeUndefined()
-    })
-})
-
-describe('isLikelySystemVolumeName', () => {
-    test('flags reserved exact names and known CapRover services', () => {
-        expect(isLikelySystemVolumeName('captain')).toBe(true)
-        expect(isLikelySystemVolumeName('registry')).toBe(true)
-        expect(isLikelySystemVolumeName('captain-nginx')).toBe(true)
-        expect(isLikelySystemVolumeName('captain-certbot')).toBe(true)
-        expect(isLikelySystemVolumeName('captain-registry')).toBe(true)
-        expect(isLikelySystemVolumeName('captain-captain')).toBe(true)
-        expect(isLikelySystemVolumeName('captain-goaccess-container')).toBe(
-            true
-        )
-        expect(isLikelySystemVolumeName('captain-netdata-container')).toBe(
-            true
-        )
-    })
-
-    test('flags namespace prefix including legacy physical volumes', () => {
-        // Legacy physical: captain--data starts with captain-
-        expect(isLikelySystemVolumeName('captain--legacy-app-data')).toBe(true)
-        expect(isLikelySystemVolumeName('captain-something')).toBe(true)
-    })
-
-    test('does not flag ordinary user volume names', () => {
-        expect(isLikelySystemVolumeName('my-postgres-data')).toBe(false)
-        expect(isLikelySystemVolumeName('app-data')).toBe(false)
-        expect(isLikelySystemVolumeName('')).toBe(false)
-    })
-
-    test('respects custom namespace prefix while keeping known CapRover names', () => {
-        expect(isLikelySystemVolumeName('customns-nginx', 'customns')).toBe(
-            true
-        )
-        expect(isLikelySystemVolumeName('customns--data', 'customns')).toBe(
-            true
-        )
-        // Ordinary name without custom prefix is not system-like
-        expect(isLikelySystemVolumeName('my-data', 'customns')).toBe(false)
-        // Known CapRover service names always match (defense in depth)
-        expect(isLikelySystemVolumeName('captain-nginx', 'customns')).toBe(
-            true
-        )
-    })
-})
-
-describe('enrichVolumesWithAppUsage', () => {
-    test('maps modern and legacy physical names to usedByAppNames', () => {
+describe('getManagedVolumes', () => {
+    test('resolves modern and legacy Persistent Directories to physical volume names', () => {
         const apps: IAllAppDefinitions = {
             modernApp: createAppDefinition({
-                volumes: [
-                    {
-                        volumeName: 'app-data',
-                        containerPath: '/data',
-                    },
-                ],
+                volumes: [{ volumeName: 'app-data', containerPath: '/data' }],
             }),
             legacyApp: createAppDefinition({
                 isLegacyAppName: true,
+                volumes: [{ volumeName: 'app-data', containerPath: '/data' }],
+            }),
+        }
+
+        expect(getManagedVolumes(apps, createMockDataStore('captain'))).toEqual(
+            [
+                { name: 'app-data', usedByAppNames: ['modernApp'] },
+                {
+                    name: 'captain--app-data',
+                    usedByAppNames: ['legacyApp'],
+                },
+            ]
+        )
+    })
+
+    test('groups a shared volume by all apps that use it', () => {
+        const apps: IAllAppDefinitions = {
+            secondApp: createAppDefinition({
+                volumes: [{ volumeName: 'shared', containerPath: '/data' }],
+            }),
+            firstApp: createAppDefinition({
+                volumes: [{ volumeName: 'shared', containerPath: '/data' }],
+            }),
+        }
+
+        expect(getManagedVolumes(apps, createMockDataStore())).toEqual([
+            {
+                name: 'shared',
+                usedByAppNames: ['firstApp', 'secondApp'],
+            },
+        ])
+    })
+
+    test('deduplicates an app that mounts the same volume more than once', () => {
+        const apps: IAllAppDefinitions = {
+            multiMountApp: createAppDefinition({
                 volumes: [
-                    {
-                        volumeName: 'app-data',
-                        containerPath: '/data',
-                    },
+                    { volumeName: 'shared', containerPath: '/one' },
+                    { volumeName: 'shared', containerPath: '/two' },
                 ],
             }),
         }
 
-        const volumes = [
-            baseVolume({ name: 'app-data' }),
-            baseVolume({ name: 'captain--app-data' }),
-            baseVolume({ name: 'orphan-vol' }),
-        ]
-
-        const result = enrichVolumesWithAppUsage(
-            volumes,
-            apps,
-            createMockDataStore('captain'),
-            'captain'
-        )
-
-        const byName = Object.fromEntries(result.map((v) => [v.name, v]))
-
-        expect(byName['app-data'].usedByAppNames).toEqual(['modernApp'])
-        expect(byName['captain--app-data'].usedByAppNames).toEqual([
-            'legacyApp',
+        expect(getManagedVolumes(apps, createMockDataStore())).toEqual([
+            { name: 'shared', usedByAppNames: ['multiMountApp'] },
         ])
-        expect(byName['orphan-vol'].usedByAppNames).toEqual([])
-        expect(byName['app-data'].isLikelySystem).toBe(false)
-        expect(byName['captain--app-data'].isLikelySystem).toBe(true)
-        expect(byName['orphan-vol'].isLikelySystem).toBe(false)
     })
 
-    test('skips bind-style Persistent Directories (hostPath only)', () => {
+    test('excludes bind-style Persistent Directories', () => {
         const apps: IAllAppDefinitions = {
             bindApp: createAppDefinition({
                 volumes: [
-                    {
-                        hostPath: '/host/path',
-                        containerPath: '/data',
-                    },
-                    {
-                        volumeName: 'named-vol',
-                        containerPath: '/named',
-                    },
+                    { hostPath: '/host/path', containerPath: '/bind' },
+                    { volumeName: 'named', containerPath: '/named' },
                 ],
             }),
         }
 
-        const volumes = [
-            baseVolume({ name: 'named-vol' }),
-            baseVolume({ name: 'unrelated' }),
-        ]
-
-        const result = enrichVolumesWithAppUsage(
-            volumes,
-            apps,
-            createMockDataStore(),
-            'captain'
-        )
-
-        expect(
-            result.find((v) => v.name === 'named-vol')!.usedByAppNames
-        ).toEqual(['bindApp'])
-        expect(
-            result.find((v) => v.name === 'unrelated')!.usedByAppNames
-        ).toEqual([])
-    })
-
-    test('dedupes app names when an app references the same volume twice', () => {
-        const apps: IAllAppDefinitions = {
-            multiMount: createAppDefinition({
-                volumes: [
-                    { volumeName: 'shared', containerPath: '/a' },
-                    { volumeName: 'shared', containerPath: '/b' },
-                ],
-            }),
-            otherApp: createAppDefinition({
-                volumes: [{ volumeName: 'shared', containerPath: '/c' }],
-            }),
-        }
-
-        const result = enrichVolumesWithAppUsage(
-            [baseVolume({ name: 'shared' })],
-            apps,
-            createMockDataStore(),
-            'captain'
-        )
-
-        expect(result[0].usedByAppNames.sort()).toEqual([
-            'multiMount',
-            'otherApp',
+        expect(getManagedVolumes(apps, createMockDataStore())).toEqual([
+            { name: 'named', usedByAppNames: ['bindApp'] },
         ])
     })
 
-    test('returns empty usedByAppNames for empty volume list', () => {
+    test('returns no volumes when there are no app definitions', () => {
+        expect(getManagedVolumes({}, createMockDataStore())).toEqual([])
+    })
+
+    test('sorts managed volumes by physical name', () => {
         const apps: IAllAppDefinitions = {
-            someApp: createAppDefinition({
-                volumes: [{ volumeName: 'x', containerPath: '/x' }],
+            zetaApp: createAppDefinition({
+                volumes: [{ volumeName: 'zeta', containerPath: '/data' }],
+            }),
+            alphaApp: createAppDefinition({
+                volumes: [{ volumeName: 'alpha', containerPath: '/data' }],
+            }),
+            middleApp: createAppDefinition({
+                volumes: [{ volumeName: 'middle', containerPath: '/data' }],
             }),
         }
 
         expect(
-            enrichVolumesWithAppUsage(
-                [],
-                apps,
-                createMockDataStore(),
-                'captain'
+            getManagedVolumes(apps, createMockDataStore()).map((volume) =>
+                volume.name
             )
-        ).toEqual([])
-    })
-})
-
-describe('sortVolumesByName', () => {
-    test('sorts by name ascending without mutating input', () => {
-        const input: VolumeListItem[] = [
-            {
-                ...baseVolume({ name: 'zeta' }),
-                usedByAppNames: [],
-                isLikelySystem: false,
-            },
-            {
-                ...baseVolume({ name: 'alpha' }),
-                usedByAppNames: [],
-                isLikelySystem: false,
-            },
-            {
-                ...baseVolume({ name: 'middle' }),
-                usedByAppNames: [],
-                isLikelySystem: false,
-            },
-        ]
-        const originalOrder = input.map((v) => v.name)
-
-        const sorted = sortVolumesByName(input)
-
-        expect(sorted.map((v) => v.name)).toEqual([
-            'alpha',
-            'middle',
-            'zeta',
-        ])
-        expect(input.map((v) => v.name)).toEqual(originalOrder)
+        ).toEqual(['alpha', 'middle', 'zeta'])
     })
 })

--- a/tests/VolumesList.test.ts
+++ b/tests/VolumesList.test.ts
@@ -1,0 +1,326 @@
+import {
+    DockerVolumeInfo,
+    mapVolumeInspectToDto,
+    VolumeInspectWithCreatedAt,
+} from '../src/docker/DockerApi'
+import {
+    enrichVolumesWithAppUsage,
+    isLikelySystemVolumeName,
+    sortVolumesByName,
+    VolumeListItem,
+} from '../src/handlers/users/system/VolumesHandler'
+import { IAllAppDefinitions, IAppDef } from '../src/models/AppDefinition'
+
+function createAppDefinition(overrides: Partial<IAppDef> = {}): IAppDef {
+    return {
+        description: '',
+        deployedVersion: 0,
+        notExposeAsWebApp: false,
+        hasPersistentData: false,
+        hasDefaultSubDomainSsl: false,
+        captainDefinitionRelativeFilePath: './captain-definition',
+        forceSsl: false,
+        websocketSupport: false,
+        instanceCount: 1,
+        networks: ['captain-overlay-network'],
+        customDomain: [],
+        ports: [],
+        volumes: [],
+        envVars: [],
+        versions: [],
+        ...overrides,
+    }
+}
+
+function createMockDataStore(namespace: string = 'captain') {
+    return {
+        getAppsDataStore: () => ({
+            getVolumeName: (volumeName: string, isLegacy: boolean) => {
+                if (isLegacy) {
+                    return `${namespace}--${volumeName}`
+                }
+                return volumeName
+            },
+        }),
+    } as any
+}
+
+function baseVolume(
+    overrides: Partial<DockerVolumeInfo> = {}
+): DockerVolumeInfo {
+    return {
+        name: 'my-data',
+        driver: 'local',
+        mountpoint: '/var/lib/docker/volumes/my-data/_data',
+        scope: 'local',
+        labels: {},
+        options: null,
+        ...overrides,
+    }
+}
+
+describe('mapVolumeInspectToDto', () => {
+    test('maps required fields and coerces null Labels to {}', () => {
+        const inspect = {
+            Name: 'vol-a',
+            Driver: 'local',
+            Mountpoint: '/var/lib/docker/volumes/vol-a/_data',
+            Scope: 'local',
+            Labels: null,
+            Options: null,
+        } as unknown as VolumeInspectWithCreatedAt
+
+        expect(mapVolumeInspectToDto(inspect)).toEqual({
+            name: 'vol-a',
+            driver: 'local',
+            mountpoint: '/var/lib/docker/volumes/vol-a/_data',
+            scope: 'local',
+            labels: {},
+            options: null,
+        })
+    })
+
+    test('maps UsageData and CreatedAt only when present', () => {
+        const inspect = {
+            Name: 'vol-b',
+            Driver: 'local',
+            Mountpoint: '/mp',
+            Scope: 'local',
+            Labels: { a: 'b' },
+            Options: { device: 'tmpfs' },
+            UsageData: { Size: 1024, RefCount: 2 },
+            CreatedAt: '2024-01-15T12:34:56Z',
+        } as VolumeInspectWithCreatedAt
+
+        expect(mapVolumeInspectToDto(inspect)).toEqual({
+            name: 'vol-b',
+            driver: 'local',
+            mountpoint: '/mp',
+            scope: 'local',
+            labels: { a: 'b' },
+            options: { device: 'tmpfs' },
+            size: 1024,
+            refCount: 2,
+            createdAt: '2024-01-15T12:34:56Z',
+        })
+    })
+
+    test('omits size/refCount when UsageData is missing (typical listVolumes)', () => {
+        const inspect = {
+            Name: 'vol-c',
+            Driver: 'local',
+            Mountpoint: '/mp',
+            Scope: 'local',
+            Labels: {},
+            Options: null,
+        } as VolumeInspectWithCreatedAt
+
+        const dto = mapVolumeInspectToDto(inspect)
+        expect(dto.size).toBeUndefined()
+        expect(dto.refCount).toBeUndefined()
+        expect(dto.createdAt).toBeUndefined()
+    })
+})
+
+describe('isLikelySystemVolumeName', () => {
+    test('flags reserved exact names and known CapRover services', () => {
+        expect(isLikelySystemVolumeName('captain')).toBe(true)
+        expect(isLikelySystemVolumeName('registry')).toBe(true)
+        expect(isLikelySystemVolumeName('captain-nginx')).toBe(true)
+        expect(isLikelySystemVolumeName('captain-certbot')).toBe(true)
+        expect(isLikelySystemVolumeName('captain-registry')).toBe(true)
+        expect(isLikelySystemVolumeName('captain-captain')).toBe(true)
+        expect(isLikelySystemVolumeName('captain-goaccess-container')).toBe(
+            true
+        )
+        expect(isLikelySystemVolumeName('captain-netdata-container')).toBe(
+            true
+        )
+    })
+
+    test('flags namespace prefix including legacy physical volumes', () => {
+        // Legacy physical: captain--data starts with captain-
+        expect(isLikelySystemVolumeName('captain--legacy-app-data')).toBe(true)
+        expect(isLikelySystemVolumeName('captain-something')).toBe(true)
+    })
+
+    test('does not flag ordinary user volume names', () => {
+        expect(isLikelySystemVolumeName('my-postgres-data')).toBe(false)
+        expect(isLikelySystemVolumeName('app-data')).toBe(false)
+        expect(isLikelySystemVolumeName('')).toBe(false)
+    })
+
+    test('respects custom namespace prefix while keeping known CapRover names', () => {
+        expect(isLikelySystemVolumeName('customns-nginx', 'customns')).toBe(
+            true
+        )
+        expect(isLikelySystemVolumeName('customns--data', 'customns')).toBe(
+            true
+        )
+        // Ordinary name without custom prefix is not system-like
+        expect(isLikelySystemVolumeName('my-data', 'customns')).toBe(false)
+        // Known CapRover service names always match (defense in depth)
+        expect(isLikelySystemVolumeName('captain-nginx', 'customns')).toBe(
+            true
+        )
+    })
+})
+
+describe('enrichVolumesWithAppUsage', () => {
+    test('maps modern and legacy physical names to usedByAppNames', () => {
+        const apps: IAllAppDefinitions = {
+            modernApp: createAppDefinition({
+                volumes: [
+                    {
+                        volumeName: 'app-data',
+                        containerPath: '/data',
+                    },
+                ],
+            }),
+            legacyApp: createAppDefinition({
+                isLegacyAppName: true,
+                volumes: [
+                    {
+                        volumeName: 'app-data',
+                        containerPath: '/data',
+                    },
+                ],
+            }),
+        }
+
+        const volumes = [
+            baseVolume({ name: 'app-data' }),
+            baseVolume({ name: 'captain--app-data' }),
+            baseVolume({ name: 'orphan-vol' }),
+        ]
+
+        const result = enrichVolumesWithAppUsage(
+            volumes,
+            apps,
+            createMockDataStore('captain'),
+            'captain'
+        )
+
+        const byName = Object.fromEntries(result.map((v) => [v.name, v]))
+
+        expect(byName['app-data'].usedByAppNames).toEqual(['modernApp'])
+        expect(byName['captain--app-data'].usedByAppNames).toEqual([
+            'legacyApp',
+        ])
+        expect(byName['orphan-vol'].usedByAppNames).toEqual([])
+        expect(byName['app-data'].isLikelySystem).toBe(false)
+        expect(byName['captain--app-data'].isLikelySystem).toBe(true)
+        expect(byName['orphan-vol'].isLikelySystem).toBe(false)
+    })
+
+    test('skips bind-style Persistent Directories (hostPath only)', () => {
+        const apps: IAllAppDefinitions = {
+            bindApp: createAppDefinition({
+                volumes: [
+                    {
+                        hostPath: '/host/path',
+                        containerPath: '/data',
+                    },
+                    {
+                        volumeName: 'named-vol',
+                        containerPath: '/named',
+                    },
+                ],
+            }),
+        }
+
+        const volumes = [
+            baseVolume({ name: 'named-vol' }),
+            baseVolume({ name: 'unrelated' }),
+        ]
+
+        const result = enrichVolumesWithAppUsage(
+            volumes,
+            apps,
+            createMockDataStore(),
+            'captain'
+        )
+
+        expect(
+            result.find((v) => v.name === 'named-vol')!.usedByAppNames
+        ).toEqual(['bindApp'])
+        expect(
+            result.find((v) => v.name === 'unrelated')!.usedByAppNames
+        ).toEqual([])
+    })
+
+    test('dedupes app names when an app references the same volume twice', () => {
+        const apps: IAllAppDefinitions = {
+            multiMount: createAppDefinition({
+                volumes: [
+                    { volumeName: 'shared', containerPath: '/a' },
+                    { volumeName: 'shared', containerPath: '/b' },
+                ],
+            }),
+            otherApp: createAppDefinition({
+                volumes: [{ volumeName: 'shared', containerPath: '/c' }],
+            }),
+        }
+
+        const result = enrichVolumesWithAppUsage(
+            [baseVolume({ name: 'shared' })],
+            apps,
+            createMockDataStore(),
+            'captain'
+        )
+
+        expect(result[0].usedByAppNames.sort()).toEqual([
+            'multiMount',
+            'otherApp',
+        ])
+    })
+
+    test('returns empty usedByAppNames for empty volume list', () => {
+        const apps: IAllAppDefinitions = {
+            someApp: createAppDefinition({
+                volumes: [{ volumeName: 'x', containerPath: '/x' }],
+            }),
+        }
+
+        expect(
+            enrichVolumesWithAppUsage(
+                [],
+                apps,
+                createMockDataStore(),
+                'captain'
+            )
+        ).toEqual([])
+    })
+})
+
+describe('sortVolumesByName', () => {
+    test('sorts by name ascending without mutating input', () => {
+        const input: VolumeListItem[] = [
+            {
+                ...baseVolume({ name: 'zeta' }),
+                usedByAppNames: [],
+                isLikelySystem: false,
+            },
+            {
+                ...baseVolume({ name: 'alpha' }),
+                usedByAppNames: [],
+                isLikelySystem: false,
+            },
+            {
+                ...baseVolume({ name: 'middle' }),
+                usedByAppNames: [],
+                isLikelySystem: false,
+            },
+        ]
+        const originalOrder = input.map((v) => v.name)
+
+        const sorted = sortVolumesByName(input)
+
+        expect(sorted.map((v) => v.name)).toEqual([
+            'alpha',
+            'middle',
+            'zeta',
+        ])
+        expect(input.map((v) => v.name)).toEqual(originalOrder)
+    })
+})


### PR DESCRIPTION
## Summary

- Add authorized `GET /api/v2/user/system/volumes/` that lists Docker named volumes on CapRover’s Docker engine endpoint (node-local).
- Enrich each volume with `usedByAppNames` (apps whose named Persistent Directories resolve to that physical volume via `getVolumeName`, including legacy `namespace--` names) and `isLikelySystem` (UX heuristic only).
- Foundation for frontend Persistent Directories conflict detection / warnings (warn-only; no server-side block).

## API

- **Path:** `GET /user/system/volumes/` (auth: `UserRouter` / `x-captain-auth`)
- **Response:** `BaseApi` with `data.volumes[]` sorted by `name` ascending
- **Fields:** `name`, `driver`, `mountpoint`, `scope`, `labels`, `options`, optional `createdAt` / `size` / `refCount`, always `usedByAppNames`, always `isLikelySystem`
- **Notes:** Inventory is node-local (not swarm-global). Do not rely on UsageData from `listVolumes` for conflict logic.

## Test plan

- [x] `npm run build` (tsc + madge circular check)
- [x] `npm run lint`
- [x] `npm run formatter`
- [x] `npm run test` (18 suites, 125 passed, 2 skipped)
- [x] Manual: authenticated `GET /api/v2/user/system/volumes/` returns 100 + volume list
- [x] Manual: unauthenticated request returns 1106
- [x] Manual: app with named Persistent Directory appears in `usedByAppNames` for matching physical volume

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated API endpoint to list CapRover-managed named volumes.
  * Volume results include the physical volume name and the apps using each volume.
  * Results are alphabetically sorted, with duplicate app references removed.
  * Added a Postman request for the new volumes endpoint.

* **Documentation**
  * Updated the changelog with details about the new API.

* **Tests**
  * Added coverage for shared, legacy, duplicate, bind-mounted, empty, and sorted volume results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->