### PR TITLE
docs: add persistent volume warning to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Next Version - available as `edge`]
 
+- New: Warning when a persistent volume label is already used by another app [PR-226](https://github.com/caprover/caprover-frontend/pull/226)
 - New: Ability to deploy simplified Docker compose [PR-191](https://github.com/caprover/caprover-frontend/pull/191)
 - New: Defaulting to BuildKit [Issue-1582](https://github.com/caprover/caprover/issues/1582)
 - New: Defaulting to gzip on [PR-2360](https://github.com/caprover/caprover/pull/2360)


### PR DESCRIPTION
## Summary

- Add the persistent volume label conflict warning to the next-version changelog.
- Link the merged frontend implementation in caprover/caprover-frontend#226.

## Validation

- Confirmed the changelog diff contains exactly one added line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry warning when persistent volume labels are already used by another application.
  * Included a reference link for additional context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->