### PR TITLE
Standardize changelog release headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## [Next Version - available as `edge`]
+## [Next Version]
+
+Available as `edge`
 
 - New: Warning when a persistent volume label is already used by another app [PR-226](https://github.com/caprover/caprover-frontend/pull/226)
 - New: Ability to deploy simplified Docker compose [PR-191](https://github.com/caprover/caprover-frontend/pull/191)
@@ -480,7 +482,7 @@ Breaking Change:
 
 - If you were manually setting port mapping on your containers before this release, make sure to re-map them through Captain interface. Since port mapping is added to the interface, Captain would override the current port mapping that you might have on your containers. If you didn't manually modified your containers `--publish-add` flag, you don't need to worry about this.
 
-## [ v0.2.2] - 2017-12-05
+## [v0.2.2] - 2017-12-05
 
 Hotfix:
 


### PR DESCRIPTION
## Summary

Standardize the two release headings that did not follow a consistent machine-readable structure:

- separate the `edge` availability note from the `Next Version` identifier
- remove the stray leading space from the `v0.2.2` identifier

All historical release notes and their wording remain unchanged.

Release headings can now be parsed consistently with:

```regex
^## \[([^\]]+)\](?: - (\d{4}-\d{2}-\d{2}))?$
```

The date is optional only for the current `Next Version` section.

## Validation

- parsed all 40 release sections successfully
- confirmed 39 sections have ISO dates and `Next Version` is the sole undated section
- confirmed there are no invalid release headings or duplicate version identifiers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog version headings for clearer formatting.
  * Clarified the availability note for the unreleased version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->