### PR TITLE
Upgrade Node.js to 24

### DIFF
--- a/.github/workflows/build_project.yml
+++ b/.github/workflows/build_project.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v5
               with:
                   node-version: 24
             - run: |

--- a/.github/workflows/build_project.yml
+++ b/.github/workflows/build_project.yml
@@ -15,7 +15,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 22
+                  node-version: 24
             - run: |
                   sudo bash -c "mkdir /captain && chown -R `whoami` /captain"
                   npm ci 

--- a/.github/workflows/format_project.yml
+++ b/.github/workflows/format_project.yml
@@ -15,5 +15,5 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 22
+                  node-version: 24
             - run: npm ci && npm run formatter

--- a/.github/workflows/format_project.yml
+++ b/.github/workflows/format_project.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v5
               with:
                   node-version: 24
             - run: npm ci && npm run formatter

--- a/.github/workflows/lint_project.yml
+++ b/.github/workflows/lint_project.yml
@@ -15,7 +15,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 22
+                  node-version: 24
             - run: |
                   sudo bash -c "mkdir /captain && chown -R `whoami` /captain"
                   npm ci

--- a/.github/workflows/lint_project.yml
+++ b/.github/workflows/lint_project.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v5
               with:
                   node-version: 24
             - run: |

--- a/.github/workflows/publish_edge.yml
+++ b/.github/workflows/publish_edge.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v5
               with:
                   node-version: 24
             - run: |

--- a/.github/workflows/publish_edge.yml
+++ b/.github/workflows/publish_edge.yml
@@ -12,7 +12,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 22
+                  node-version: 24
             - run: |
                   sudo bash -c "mkdir /captain && chown -R `whoami` /captain"
                   npm ci

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v5
               with:
                   node-version: 24
             - run: |

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -12,7 +12,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 22
+                  node-version: 24
             - run: |
                   sudo bash -c "mkdir /captain && chown -R `whoami` /captain"
                   npm ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ The frontend is maintained in `caprover/caprover-frontend`. User-facing document
 
 ## Validation
 
-Use Node.js 22.
+Use Node.js 24.
 
 ```bash
 npm ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Link this folder to the root folder (Apple does not allow to create folder on th
 
 #####
 
-use node 22 then
+use node 24 then
 
 ```bash
 $   npm install

--- a/dev-scripts/build_and_push_edge.sh
+++ b/dev-scripts/build_and_push_edge.sh
@@ -58,7 +58,7 @@ docker buildx create --name mybuilder
 docker buildx use mybuilder
 
 # docker buildx build --platform linux/arm -t $IMAGE_NAME:$CAPROVER_VERSION -t $IMAGE_NAME:latest  -f dockerfile-captain.edge --push .
-docker buildx build --platform linux/amd64,linux/arm64,linux/arm -t $IMAGE_NAME:$CAPROVER_VERSION -t $IMAGE_NAME:latest -f dockerfile-captain.edge --push .
+docker buildx build --platform linux/amd64,linux/arm64 -t $IMAGE_NAME:$CAPROVER_VERSION -t $IMAGE_NAME:latest -f dockerfile-captain.edge --push .
 
 # docker build -t $IMAGE_NAME:$CAPROVER_VERSION -t $IMAGE_NAME:latest  -f dockerfile-captain.edge .
 # docker push $IMAGE_NAME:latest

--- a/dev-scripts/build_and_push_release.sh
+++ b/dev-scripts/build_and_push_release.sh
@@ -71,4 +71,4 @@ docker buildx rm mybuilder || echo "mybuilder not found"
 docker buildx create --name mybuilder
 docker buildx use mybuilder
 
-docker buildx build --platform linux/amd64,linux/arm64,linux/arm -t $IMAGE_NAME:$CAPROVER_VERSION -t $IMAGE_NAME:latest -f dockerfile-captain.release --push .
+docker buildx build --platform linux/amd64,linux/arm64 -t $IMAGE_NAME:$CAPROVER_VERSION -t $IMAGE_NAME:latest -f dockerfile-captain.release --push .

--- a/dockerfile-captain.debug
+++ b/dockerfile-captain.debug
@@ -1,4 +1,4 @@
-FROM node:22
+FROM node:24
 RUN apt-get update && apt-get full-upgrade -yqq && apt-get install build-essential cmake -yqq
 
 RUN apt-get -y install netcat-traditional socat

--- a/dockerfile-captain.dev
+++ b/dockerfile-captain.dev
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:24-alpine
 RUN apk update && apk upgrade --no-cache && apk add --update --no-cache make gcc g++ git curl openssl openssh
 
 RUN mkdir -p /usr/src/app

--- a/dockerfile-captain.edge
+++ b/dockerfile-captain.edge
@@ -1,5 +1,5 @@
-# Build stage runs on the host platform to avoid QEMU SIGILL issues with Node.js 22 on arm64
-FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
+# Build stage runs on the host platform to avoid QEMU SIGILL issues with Node.js 24 on arm64
+FROM --platform=$BUILDPLATFORM node:24-alpine AS builder
 RUN apk add --update --no-cache make gcc g++ git curl openssl
 
 WORKDIR /usr/src/app
@@ -13,7 +13,7 @@ RUN npm ci && \
      mv ./edge-override.json ./config-override.json
 
 # Final stage uses the target platform's Node.js runtime
-FROM node:22-alpine
+FROM node:24-alpine
 RUN apk add --update --no-cache git curl openssl openssh
 
 WORKDIR /usr/src/app

--- a/dockerfile-captain.release
+++ b/dockerfile-captain.release
@@ -1,5 +1,5 @@
-# Build stage runs on the host platform to avoid QEMU SIGILL issues with Node.js 22 on arm64
-FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
+# Build stage runs on the host platform to avoid QEMU SIGILL issues with Node.js 24 on arm64
+FROM --platform=$BUILDPLATFORM node:24-alpine AS builder
 RUN apk add --update --no-cache make gcc g++ git curl openssl
 
 WORKDIR /usr/src/app
@@ -12,7 +12,7 @@ RUN npm ci && \
      npm cache clean --force
 
 # Final stage uses the target platform's Node.js runtime
-FROM node:22-alpine
+FROM node:24-alpine
 RUN apk add --update --no-cache git curl openssl openssh
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
Previous Node bump: https://github.com/caprover/caprover/commit/683f353533f12c50327b9d17bb4b66deec198a7a


## Summary

- upgrade GitHub Actions from Node.js 22 to Node.js 24
- upgrade debug, development, edge, and release Docker images to Node.js 24
- update contributor and agent guidance to reference Node.js 24
- preserve the current multi-stage edge and release image structure

This follows the scope of commit `683f353533f12c50327b9d17bb4b66deec198a7a`, which upgraded Node.js 18 to 22, while also updating the newer `AGENTS.md` reference and both stages of the current multi-stage Dockerfiles.

## Impact

CapRover development, CI checks, and published images will use Node.js 24.

## Validation

- verified the branch is exactly one commit ahead of `master`
- verified all 11 modified files contain only targeted Node.js 22 to 24 replacements
- GitHub pull-request checks will run the repository build, lint, formatter, and tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build, formatting, linting, publishing, and release environments to Node.js 24.
  * Upgraded development, edge, debug, and release container images to Node.js 24.
  * Updated the Node.js setup action used by automated workflows.
  * Edge and release image builds now target amd64 and arm64 platforms; ARMv7 images are no longer provided.

* **Documentation**
  * Updated development requirements and macOS setup guidance to specify Node.js 24.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->