### PR TITLE
Fix app upload route typing after dependency refresh

### DIFF
--- a/src/routes/user/apps/appdata/AppDataRouter.ts
+++ b/src/routes/user/apps/appdata/AppDataRouter.ts
@@ -71,7 +71,7 @@ router.post('/:appName/', function (req, res, next) {
 })
 
 // uploadCaptainDefinitionContent
-router.post(
+router.post<{ appName: string }>(
     '/:appName/',
     upload.single('sourceFile'),
     function (req, res, next) {


### PR DESCRIPTION
## Summary

Add the explicit `{ appName: string }` route-parameter type to the app upload route.

## Root cause

The recent lockfile refresh upgraded `@types/express-serve-static-core` from 5.0.7 to 5.1.3. Its default route-parameter type can now include `string[]` for wildcard parameters. With Multer middleware on this route, TypeScript inferred `req.params.appName` as `string | string[]`, which cannot be passed to the upload handler's string-only `appName` field.

This caused both the master build and the edge-image precheck to fail at `AppDataRouter.ts:89`. The route uses a normal named segment, so its runtime value is a single string.

## Impact

Restores TypeScript compilation and unblocks the master and edge-image workflows. There is no runtime behavior or API change.

## Validation

- `npm ci`
- `npm run formatter`
- `npm run lint`
- `npm run build`
- `npm test -- --runInBand`: all 17 suites passed, with 113 tests passed and 2 skipped. The command then exited 1 because existing asynchronous Docker initialization attempted to access unavailable `/var/run/docker.sock` after the tests completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Clarified the upload route’s parameter typing without changing its runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->