### PR TITLE
Release 1.15.1: Fix one-click deployment analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Available as `edge`
 
 - TBD
 
+## [1.15.1] - 2026-08-08
+
+- Fixed: Custom one-click app template and Docker Compose deployments failing to start [PR-2453](https://github.com/caprover/caprover/pull/2453)
+
 ## [1.15.0] - 2026-08-04
 
 - New: Warning when a persistent volume label is already used by another app [PR-226](https://github.com/caprover/caprover-frontend/pull/226)

--- a/src/routes/user/oneclick/OneClickAppRouter.ts
+++ b/src/routes/user/oneclick/OneClickAppRouter.ts
@@ -384,7 +384,7 @@ export function reportAnalyticsOnAppDeploy(
         templateName === 'DOCKER_COMPOSE'
     ) {
         if (template?.services) {
-            template.services.forEach((service: any) => {
+            Object.values(template.services).forEach((service: any) => {
                 if (service && typeof service === 'object') {
                     Object.keys(service).forEach((key) => {
                         if (

--- a/src/utils/CaptainConstants.ts
+++ b/src/utils/CaptainConstants.ts
@@ -17,7 +17,7 @@ const CONSTANT_FILE_OVERRIDE_USER =
 const configs = {
     publishedNameOnDockerHub: 'caprover/caprover',
 
-    version: '1.15.0',
+    version: '1.15.1',
 
     defaultMaxLogSize: '512m',
 

--- a/tests/OneClickAppRouter.test.ts
+++ b/tests/OneClickAppRouter.test.ts
@@ -167,14 +167,14 @@ describe('reportAnalyticsOnAppDeploy', () => {
         test('should track unused fields for TEMPLATE_ONE_CLICK', () => {
             const templateName = 'TEMPLATE_ONE_CLICK'
             const template = {
-                services: [
-                    {
+                services: {
+                    app: {
                         image: 'nginx:latest',
                         environment: { VAR: 'value' },
                         custom_field: 'value',
                         another_field: 'value2',
                     },
-                ],
+                },
             }
 
             reportAnalyticsOnAppDeploy(templateName, template, mockEventLogger)
@@ -186,14 +186,14 @@ describe('reportAnalyticsOnAppDeploy', () => {
         test('should track unused fields for DOCKER_COMPOSE', () => {
             const templateName = 'DOCKER_COMPOSE'
             const template = {
-                services: [
-                    {
+                services: {
+                    database: {
                         image: 'postgres:latest',
                         volumes: ['/data:/var/lib/postgresql/data'],
                         restart: 'always',
                         networks: ['backend'],
                     },
-                ],
+                },
             }
 
             reportAnalyticsOnAppDeploy(templateName, template, mockEventLogger)
@@ -228,19 +228,19 @@ describe('reportAnalyticsOnAppDeploy', () => {
         test('should handle multiple services with mixed fields', () => {
             const templateName = 'DOCKER_COMPOSE'
             const template = {
-                services: [
-                    {
+                services: {
+                    web: {
                         image: 'nginx:latest',
                         ports: ['80:80'],
                         custom_field1: 'value1',
                     },
-                    {
+                    database: {
                         image: 'postgres:latest',
                         environment: { POSTGRES_DB: 'mydb' },
                         custom_field2: 'value2',
                         another_custom: 'value3',
                     },
-                ],
+                },
             }
 
             reportAnalyticsOnAppDeploy(templateName, template, mockEventLogger)


### PR DESCRIPTION
## Summary

- iterate over one-click and Docker Compose services as a keyed object
- update the focused analytics tests to use the real template shape
- bump the CapRover version to 1.15.1
- add the 1.15.1 changelog entry

## Root cause

One-click templates and Docker Compose define `services` as an object keyed by service name. The deployment analytics added in 1.15.0 called `template.services.forEach(...)`, treating that object as an array.

For custom one-click templates and Docker Compose deployments, this threw `TypeError: template.services.forEach is not a function` before the deployment job started. The backend returned HTTP 500, which the frontend surfaced as "Something bad happened."

Using `Object.values(template.services)` preserves the existing analytics behavior while supporting the actual template schema.

The existing tests used arrays for `services`, so they did not represent real one-click or Compose payloads and missed the regression.

## Release

This branch is based on `release` at 1.15.0 and prepares the 1.15.1 hotfix.

## Validation

- `npm test -- --runInBand tests/OneClickAppRouter.test.ts`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed custom one-click app templates and Docker Compose deployments that could fail to start.
  * Improved analytics tracking for deployments with one or multiple named services.

* **Chores**
  * Updated the reported CapRover version to 1.15.1.
  * Added release notes documenting the deployment fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->