### PR TITLE
Fix legacy Captain NGINX template compatibility

### DIFF
--- a/src/user/system/LoadBalancerManager.ts
+++ b/src/user/system/LoadBalancerManager.ts
@@ -540,6 +540,8 @@ class LoadBalancerManager {
                         domain: captainDomain,
                         serviceContainerPort3000:
                             CaptainConstants.serviceContainerPort3000,
+                        // Backwards compatibility for custom templates created before v1.15.0.
+                        // https://github.com/caprover/caprover/issues/2455
                         serviceExposedPort:
                             CaptainConstants.serviceContainerPort3000,
                         defaultHtmlDir:

--- a/src/user/system/LoadBalancerManager.ts
+++ b/src/user/system/LoadBalancerManager.ts
@@ -540,6 +540,8 @@ class LoadBalancerManager {
                         domain: captainDomain,
                         serviceContainerPort3000:
                             CaptainConstants.serviceContainerPort3000,
+                        serviceExposedPort:
+                            CaptainConstants.serviceContainerPort3000,
                         defaultHtmlDir:
                             CaptainConstants.nginxStaticRootDir +
                             CaptainConstants.nginxDefaultHtmlDir,


### PR DESCRIPTION
Fixes #2455.

## What changed

Restore `captain.serviceExposedPort` in the Captain root NGINX template render context as a backwards-compatible alias for `CaptainConstants.serviceContainerPort3000`.

## Why

CapRover 1.15.x renamed the template variable from `captain.serviceExposedPort` to `captain.serviceContainerPort3000`. Users with a customized Captain NGINX template persisted from an older release still reference the old variable. EJS renders that missing value as empty, producing an upstream such as `http://captain-captain:`, which breaks access to the dashboard after upgrade.

The alias uses the internal container port, not the configurable published admin port, because NGINX reaches Captain inside the swarm network.

## Scope

This intentionally avoids template migration or generic EJS variable validation. User-editable template variables should remain backwards compatible, and retaining this alias is the smallest safe fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Captain’s NGINX configuration to correctly expose the service on port 3000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->