### PR TITLE
Release 1.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Available as `edge`
 
 - TBD
 
+## [1.15.2] - 2026-08-14
+
+- Fixed: Legacy custom Captain NGINX templates failing after upgrading to v1.15.0 [Issue-2455](https://github.com/caprover/caprover/issues/2455)
+- Fixed: Authentication not persisting after reloading the dashboard [PR-230](https://github.com/caprover/caprover-frontend/pull/230)
+
 ## [1.15.1] - 2026-08-08
 
 - Fixed: Custom one-click app template and Docker Compose deployments failing to start [PR-2453](https://github.com/caprover/caprover/pull/2453)

--- a/dev-scripts/build_and_push_release.sh
+++ b/dev-scripts/build_and_push_release.sh
@@ -44,7 +44,7 @@ echo $IMAGE_NAME:$CAPROVER_VERSION
 echo "**************************************"
 echo "**************************************"
 
-FRONTEND_COMMIT_HASH=8db9fcd57f88be9bae12d1acc0daa4a4dfc604a2
+FRONTEND_COMMIT_HASH=5db8b202774fb50c9ecdddc42020bb454d64c42d
 
 ## Building frontend app
 ORIG_DIR=$(pwd)

--- a/src/user/system/LoadBalancerManager.ts
+++ b/src/user/system/LoadBalancerManager.ts
@@ -540,6 +540,10 @@ class LoadBalancerManager {
                         domain: captainDomain,
                         serviceContainerPort3000:
                             CaptainConstants.serviceContainerPort3000,
+                        // Backwards compatibility for custom templates created before v1.15.0.
+                        // https://github.com/caprover/caprover/issues/2455
+                        serviceExposedPort:
+                            CaptainConstants.serviceContainerPort3000,
                         defaultHtmlDir:
                             CaptainConstants.nginxStaticRootDir +
                             CaptainConstants.nginxDefaultHtmlDir,

--- a/src/utils/CaptainConstants.ts
+++ b/src/utils/CaptainConstants.ts
@@ -17,7 +17,7 @@ const CONSTANT_FILE_OVERRIDE_USER =
 const configs = {
     publishedNameOnDockerHub: 'caprover/caprover',
 
-    version: '1.15.1',
+    version: '1.15.2',
 
     defaultMaxLogSize: '512m',
 


### PR DESCRIPTION
## Summary

Prepare CapRover 1.15.2 with two compatibility fixes:

- restore the legacy `serviceExposedPort` template variable for custom Captain NGINX templates created before v1.15.0
- update the bundled frontend to `5db8b202774fb50c9ecdddc42020bb454d64c42d`, which preserves authentication after a dashboard reload
- bump the backend version to 1.15.2
- add the 1.15.2 changelog entry

## Why

CapRover 1.15.0 renamed the Captain template variable to `serviceContainerPort3000`, which broke existing custom templates that still reference `serviceExposedPort`. The frontend update fixes persisted authentication not being restored during initialization.

## Impact

Existing custom Captain NGINX templates remain compatible, and signed-in dashboard sessions continue working after a page reload.

## Validation

- Prettier formatting check
- ESLint
- circular-dependency scan
- TypeScript build
- full Jest suite: 17 suites passed, 113 tests passed, 2 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with legacy custom NGINX templates.
  - Fixed dashboard authentication persistence so login sessions are retained more reliably.

- **Release**
  - Updated the platform to version 1.15.2 with the latest frontend release included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->