### PR TITLE
Fix renamed apps keeping stale built image tags

### DIFF
--- a/src/datastore/AppsDataStore.ts
+++ b/src/datastore/AppsDataStore.ts
@@ -16,6 +16,7 @@ import {
 import { IBuiltImage } from '../models/IBuiltImage'
 import Authenticator from '../user/Authenticator'
 import ApacheMd5 from '../utils/ApacheMd5'
+import { rewriteCapRoverBuiltImageName } from '../utils/BuiltImageName'
 import CaptainConstants from '../utils/CaptainConstants'
 import CaptainEncryptor from '../utils/Encryptor'
 import Logger from '../utils/Logger'
@@ -302,6 +303,23 @@ class AppsDataStore {
             .then(function (appData) {
                 if (appData.appName) appData.appName = newAppName
                 appData.hasDefaultSubDomainSsl = false
+
+                const versions = appData.versions || []
+                for (let i = 0; i < versions.length; i++) {
+                    const deployedImageName = versions[i].deployedImageName
+                    if (!deployedImageName) {
+                        continue
+                    }
+
+                    versions[i].deployedImageName =
+                        rewriteCapRoverBuiltImageName(
+                            deployedImageName,
+                            self.namepace,
+                            oldAppName,
+                            newAppName
+                        )
+                }
+
                 return self.saveApp(newAppName, appData)
             })
             .then(function () {

--- a/src/user/DockerRegistryHelper.ts
+++ b/src/user/DockerRegistryHelper.ts
@@ -2,6 +2,7 @@ import ApiStatusCodes from '../api/ApiStatusCodes'
 import DataStore from '../datastore/DataStore'
 import RegistriesDataStore from '../datastore/RegistriesDataStore'
 import DockerApi from '../docker/DockerApi'
+import { IAppVersion } from '../models/AppDefinition'
 import { DockerAuthObj, DockerRegistryConfig } from '../models/DockerAuthObj'
 import {
     IRegistryInfo,
@@ -9,6 +10,7 @@ import {
     IRegistryTypes,
 } from '../models/IRegistryInfo'
 import { AnyError } from '../models/OtherTypes'
+import { rewriteCapRoverBuiltImageName } from '../utils/BuiltImageName'
 import Logger from '../utils/Logger'
 import Utils from '../utils/Utils'
 import BuildLog from './BuildLog'
@@ -107,6 +109,115 @@ class DockerRegistryHelper {
                         return fullImageName
                     })
             })
+    }
+
+    retagAndPushImagesForAppRename(
+        versions: IAppVersion[],
+        namespace: string,
+        oldAppName: string,
+        newAppName: string,
+        buildLogs: BuildLog
+    ) {
+        const self = this
+        const alreadyRetagged: { [imageName: string]: boolean } = {}
+
+        return Promise.resolve() //
+            .then(function () {
+                return self.getAllRegistries()
+            })
+            .then(function (registries) {
+                let chain = Promise.resolve()
+
+                versions.forEach(function (version) {
+                    const oldImageName = version.deployedImageName
+                    if (!oldImageName) {
+                        return
+                    }
+
+                    const newImageName = rewriteCapRoverBuiltImageName(
+                        oldImageName,
+                        namespace,
+                        oldAppName,
+                        newAppName
+                    )
+
+                    if (
+                        newImageName === oldImageName ||
+                        alreadyRetagged[oldImageName]
+                    ) {
+                        return
+                    }
+
+                    alreadyRetagged[oldImageName] = true
+
+                    chain = chain
+                        .then(function () {
+                            Logger.d(
+                                `Retagging image for renamed app: ${oldImageName} -> ${newImageName}`
+                            )
+                            return self.retagImagePossiblyPulling(
+                                oldImageName,
+                                newImageName
+                            )
+                        })
+                        .then(function () {
+                            const matchingRegistry = registries.find(
+                                function (registry) {
+                                    return newImageName.startsWith(
+                                        `${registry.registryDomain}/`
+                                    )
+                                }
+                            )
+
+                            if (!matchingRegistry) {
+                                return
+                            }
+
+                            return self
+                                .getDockerAuthObjectForImageName(newImageName)
+                                .then(function (authObj) {
+                                    if (!authObj) {
+                                        throw new Error(
+                                            'Docker Auth Object is NULL just after re-tagging! Something is wrong!'
+                                        )
+                                    }
+
+                                    return self.dockerApi.pushImage(
+                                        newImageName,
+                                        authObj,
+                                        buildLogs
+                                    )
+                                })
+                        })
+                })
+
+                return chain
+            })
+    }
+
+    private retagImagePossiblyPulling(
+        oldImageName: string,
+        newImageName: string
+    ) {
+        const self = this
+
+        return self.dockerApi.retag(oldImageName, newImageName).catch(function (
+            error: AnyError
+        ) {
+            Logger.d(
+                `Local retag failed for ${oldImageName}, pulling before retrying`
+            )
+            Logger.e(error)
+
+            return self
+                .getDockerAuthObjectForImageName(oldImageName)
+                .then(function (authObj) {
+                    return self.dockerApi.pullImage(oldImageName, authObj)
+                })
+                .then(function () {
+                    return self.dockerApi.retag(oldImageName, newImageName)
+                })
+        })
     }
 
     getDockerAuthObjectForImageName(

--- a/src/user/ImageMaker.ts
+++ b/src/user/ImageMaker.ts
@@ -46,6 +46,7 @@ import { IHashMapGeneric } from '../models/ICacheGeneric'
 import { ICaptainDefinition } from '../models/ICaptainDefinition'
 import { IImageSource } from '../models/IImageSource'
 import { AnyError } from '../models/OtherTypes'
+import { getCapRoverBuiltImageRepo } from '../utils/BuiltImageName'
 import CaptainConstants from '../utils/CaptainConstants'
 import GitHelper from '../utils/GitHelper'
 import BuildLog from './BuildLog'
@@ -112,9 +113,10 @@ export default class ImageMaker {
         const rawDir = `${baseDir}/${RAW_SOURCE_DIRECTORY}`
         const tarFilePath = `${baseDir}/${TAR_FILE_NAME_READY_FOR_DOCKER}`
 
-        const baseImageNameWithoutVerAndReg = `img-${this.namespace}-${
-            appName // img-captain-myapp
-        }`
+        const baseImageNameWithoutVerAndReg = getCapRoverBuiltImageRepo(
+            this.namespace,
+            appName
+        )
         let fullImageName = '' // repo.domain.com:998/username/reponame:8
 
         return Promise.resolve() //

--- a/src/user/ServiceManager.ts
+++ b/src/user/ServiceManager.ts
@@ -441,19 +441,32 @@ class ServiceManager {
 
                 dataStore.getAppsDataStore().nameAllowedOrThrow(newAppName)
 
-                return self.ensureNotBuilding(oldAppName)
+                self.ensureNotBuilding(oldAppName)
+
+                return appDef
+            })
+            .then(function (appDef) {
+                Logger.d(`Check if service is running: ${oldServiceName}`)
+                return dockerApi
+                    .isServiceRunningByName(oldServiceName)
+                    .then(function (isRunning) {
+                        if (!isRunning) {
+                            throw ApiStatusCodes.createError(
+                                ApiStatusCodes.STATUS_ERROR_GENERIC,
+                                'Service is not running!'
+                            )
+                        }
+
+                        return self.dockerRegistryHelper.retagAndPushImagesForAppRename(
+                            appDef.versions || [],
+                            dataStore.getNameSpace(),
+                            oldAppName,
+                            newAppName,
+                            self.buildLogsManager.getAppBuildLogs(oldAppName)
+                        )
+                    })
             })
             .then(function () {
-                Logger.d(`Check if service is running: ${oldServiceName}`)
-                return dockerApi.isServiceRunningByName(oldServiceName)
-            })
-            .then(function (isRunning) {
-                if (!isRunning) {
-                    throw ApiStatusCodes.createError(
-                        ApiStatusCodes.STATUS_ERROR_GENERIC,
-                        'Service is not running!'
-                    )
-                }
                 return dockerApi.removeServiceByName(oldServiceName)
             })
             .then(function () {

--- a/src/utils/BuiltImageName.ts
+++ b/src/utils/BuiltImageName.ts
@@ -1,0 +1,30 @@
+export function getCapRoverBuiltImageRepo(namespace: string, appName: string) {
+    return `img-${namespace}-${appName}`
+}
+
+function escapeRegExp(value: string) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Rewrites CapRover-built image names (local or registry-prefixed) when an
+ * app is renamed. Third-party images and the placeholder image are left
+ * unchanged. The old app name is matched as a full image repository segment
+ * so that renaming app-1 does not affect img-captain-app-10.
+ */
+export function rewriteCapRoverBuiltImageName(
+    imageName: string,
+    namespace: string,
+    oldAppName: string,
+    newAppName: string
+) {
+    if (!imageName || !oldAppName || !newAppName || oldAppName === newAppName) {
+        return imageName
+    }
+
+    const oldRepo = getCapRoverBuiltImageRepo(namespace, oldAppName)
+    const newRepo = getCapRoverBuiltImageRepo(namespace, newAppName)
+    const repoPattern = new RegExp(`(^|/)${escapeRegExp(oldRepo)}(?=[:@]|$)`)
+
+    return imageName.replace(repoPattern, `$1${newRepo}`)
+}

--- a/tests/AppRenameImage.test.ts
+++ b/tests/AppRenameImage.test.ts
@@ -1,0 +1,469 @@
+/**
+ * After an app is renamed, CapRover-built image tags must follow the new
+ * app name. Otherwise creating a new app with the old name overwrites the
+ * shared tag, and scaling the renamed app back up runs the wrong image.
+ * See https://github.com/caprover/caprover/issues/2211
+ */
+
+import AppsDataStore from '../src/datastore/AppsDataStore'
+import { IAppDef } from '../src/models/AppDefinition'
+import { IRegistryTypes } from '../src/models/IRegistryInfo'
+import Authenticator from '../src/user/Authenticator'
+import BuildLog from '../src/user/BuildLog'
+import DockerRegistryHelper from '../src/user/DockerRegistryHelper'
+import ServiceManager from '../src/user/ServiceManager'
+import { rewriteCapRoverBuiltImageName } from '../src/utils/BuiltImageName'
+import Utils from '../src/utils/Utils'
+
+function createConfigStore(initialData: { [key: string]: any }) {
+    const data = JSON.parse(JSON.stringify(initialData))
+
+    function getByPath(key: string) {
+        return key.split('.').reduce((current: any, part: string) => {
+            if (current == null) {
+                return undefined
+            }
+            return current[part]
+        }, data)
+    }
+
+    return {
+        get: jest.fn((key: string) => getByPath(key)),
+        set: jest.fn((key: string, value: any) => {
+            const parts = key.split('.')
+            let current = data
+            for (let i = 0; i < parts.length - 1; i++) {
+                if (
+                    !current[parts[i]] ||
+                    typeof current[parts[i]] !== 'object'
+                ) {
+                    current[parts[i]] = {}
+                }
+                current = current[parts[i]]
+            }
+            current[parts[parts.length - 1]] = value
+        }),
+        delete: jest.fn((key: string) => {
+            const parts = key.split('.')
+            let current = data
+            for (let i = 0; i < parts.length - 1; i++) {
+                if (!current[parts[i]]) {
+                    return
+                }
+                current = current[parts[i]]
+            }
+            delete current[parts[parts.length - 1]]
+        }),
+    }
+}
+
+function createDeployedApp(overrides: Partial<IAppDef> = {}): IAppDef {
+    return {
+        description: '',
+        deployedVersion: 1,
+        notExposeAsWebApp: false,
+        hasPersistentData: false,
+        hasDefaultSubDomainSsl: false,
+        captainDefinitionRelativeFilePath: './captain-definition',
+        forceSsl: false,
+        websocketSupport: false,
+        instanceCount: 1,
+        networks: ['captain-overlay-network'],
+        customDomain: [],
+        ports: [],
+        volumes: [],
+        envVars: [],
+        versions: [
+            {
+                version: 0,
+                gitHash: 'aaa',
+                timeStamp: '2024-01-01T00:00:00.000Z',
+                deployedImageName: 'img-captain-app-1:0',
+            },
+            {
+                version: 1,
+                gitHash: 'bbb',
+                timeStamp: '2024-01-02T00:00:00.000Z',
+                deployedImageName: 'img-captain-app-1:1',
+            },
+        ],
+        ...overrides,
+    }
+}
+
+const authenticator = {
+    getAppPushWebhookToken: jest.fn().mockResolvedValue('unused'),
+} as unknown as Authenticator
+
+describe('rewriteCapRoverBuiltImageName', () => {
+    const namespace = 'captain'
+
+    test('rewrites a local CapRover-built image tag', () => {
+        expect(
+            rewriteCapRoverBuiltImageName(
+                'img-captain-app-1:1',
+                namespace,
+                'app-1',
+                'app-2'
+            )
+        ).toBe('img-captain-app-2:1')
+    })
+
+    test('rewrites a self-hosted registry image tag', () => {
+        expect(
+            rewriteCapRoverBuiltImageName(
+                'registry.example.com:996/captain/img-captain-app-1:1',
+                namespace,
+                'app-1',
+                'app-2'
+            )
+        ).toBe('registry.example.com:996/captain/img-captain-app-2:1')
+    })
+
+    test('does not rewrite a third-party image', () => {
+        expect(
+            rewriteCapRoverBuiltImageName(
+                'nginx:1.27',
+                namespace,
+                'app-1',
+                'app-2'
+            )
+        ).toBe('nginx:1.27')
+    })
+
+    test('does not rewrite the placeholder image', () => {
+        expect(
+            rewriteCapRoverBuiltImageName(
+                'caprover/caprover-placeholder-app:latest',
+                namespace,
+                'app-1',
+                'app-2'
+            )
+        ).toBe('caprover/caprover-placeholder-app:latest')
+    })
+
+    test('does not rewrite a longer app name that shares a prefix', () => {
+        expect(
+            rewriteCapRoverBuiltImageName(
+                'img-captain-app-10:1',
+                namespace,
+                'app-1',
+                'app-2'
+            )
+        ).toBe('img-captain-app-10:1')
+    })
+})
+
+describe('AppsDataStore.renameApp image names', () => {
+    beforeEach(() => {
+        jest.spyOn(Utils, 'getDelayedPromise').mockResolvedValue(undefined)
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    test('updates stored CapRover-built image tags when the app is renamed', async () => {
+        const store = new AppsDataStore(
+            createConfigStore({
+                appDefinitions: {
+                    'app-1': createDeployedApp(),
+                },
+            }) as any,
+            'captain'
+        )
+
+        await store.renameApp(authenticator, 'app-1', 'app-2')
+
+        await expect(store.getAppDefinition('app-1')).rejects.toThrow(
+            'App (app-1) could not be found'
+        )
+
+        const renamed = await store.getAppDefinition('app-2')
+        expect(
+            renamed.versions.map((version) => version.deployedImageName)
+        ).toEqual(['img-captain-app-2:0', 'img-captain-app-2:1'])
+        expect(renamed.deployedVersion).toBe(1)
+    })
+
+    test('updates registry-prefixed image tags without touching third-party images', async () => {
+        const store = new AppsDataStore(
+            createConfigStore({
+                appDefinitions: {
+                    'app-1': createDeployedApp({
+                        versions: [
+                            {
+                                version: 0,
+                                gitHash: undefined,
+                                timeStamp: '2024-01-01T00:00:00.000Z',
+                                deployedImageName:
+                                    'registry.example.com:996/captain/img-captain-app-1:0',
+                            },
+                            {
+                                version: 1,
+                                gitHash: undefined,
+                                timeStamp: '2024-01-02T00:00:00.000Z',
+                                deployedImageName: 'nginx:1.27',
+                            },
+                            {
+                                version: 2,
+                                gitHash: undefined,
+                                timeStamp: '2024-01-03T00:00:00.000Z',
+                            },
+                        ],
+                    }),
+                },
+            }) as any,
+            'captain'
+        )
+
+        await store.renameApp(authenticator, 'app-1', 'app-2')
+
+        const renamed = await store.getAppDefinition('app-2')
+        expect(
+            renamed.versions.map((version) => version.deployedImageName)
+        ).toEqual([
+            'registry.example.com:996/captain/img-captain-app-2:0',
+            'nginx:1.27',
+            undefined,
+        ])
+    })
+})
+
+describe('DockerRegistryHelper.retagAndPushImagesForAppRename', () => {
+    function createHelper(dockerApi: any, registries: any[] = []) {
+        const dataStore = {
+            getRegistriesDataStore: () => ({
+                getAllRegistries: jest.fn().mockResolvedValue(registries),
+                getDefaultPushRegistryId: jest
+                    .fn()
+                    .mockResolvedValue(
+                        registries[0] ? registries[0].id : undefined
+                    ),
+            }),
+        }
+        return new DockerRegistryHelper(dataStore as any, dockerApi)
+    }
+
+    const buildLogs = new BuildLog(10)
+
+    test('retags local CapRover-built images and does not push them', async () => {
+        const dockerApi = {
+            retag: jest.fn().mockResolvedValue(undefined),
+            pullImage: jest.fn().mockResolvedValue(undefined),
+            pushImage: jest.fn().mockResolvedValue(undefined),
+        }
+        const helper = createHelper(dockerApi)
+
+        await helper.retagAndPushImagesForAppRename(
+            [
+                {
+                    version: 0,
+                    gitHash: undefined,
+                    timeStamp: '2024-01-01T00:00:00.000Z',
+                    deployedImageName: 'img-captain-app-1:0',
+                },
+                {
+                    version: 1,
+                    gitHash: undefined,
+                    timeStamp: '2024-01-02T00:00:00.000Z',
+                    deployedImageName: 'img-captain-app-1:1',
+                },
+            ],
+            'captain',
+            'app-1',
+            'app-2',
+            buildLogs
+        )
+
+        expect(dockerApi.retag.mock.calls).toEqual([
+            ['img-captain-app-1:0', 'img-captain-app-2:0'],
+            ['img-captain-app-1:1', 'img-captain-app-2:1'],
+        ])
+        expect(dockerApi.pushImage).not.toHaveBeenCalled()
+    })
+
+    test('retags and pushes self-hosted registry images so swarm nodes can pull the new tag', async () => {
+        const dockerApi = {
+            retag: jest.fn().mockResolvedValue(undefined),
+            pullImage: jest.fn().mockResolvedValue(undefined),
+            pushImage: jest.fn().mockResolvedValue(undefined),
+        }
+        const helper = createHelper(dockerApi, [
+            {
+                id: 'local-reg',
+                registryUser: 'captain',
+                registryPassword: 'secret',
+                registryDomain: 'registry.example.com:996',
+                registryImagePrefix: 'captain',
+                registryType: IRegistryTypes.LOCAL_REG,
+            },
+        ])
+
+        await helper.retagAndPushImagesForAppRename(
+            [
+                {
+                    version: 1,
+                    gitHash: undefined,
+                    timeStamp: '2024-01-02T00:00:00.000Z',
+                    deployedImageName:
+                        'registry.example.com:996/captain/img-captain-app-1:1',
+                },
+            ],
+            'captain',
+            'app-1',
+            'app-2',
+            buildLogs
+        )
+
+        expect(dockerApi.retag).toHaveBeenCalledWith(
+            'registry.example.com:996/captain/img-captain-app-1:1',
+            'registry.example.com:996/captain/img-captain-app-2:1'
+        )
+        expect(dockerApi.pushImage).toHaveBeenCalledTimes(1)
+        expect(dockerApi.pushImage.mock.calls[0][0]).toBe(
+            'registry.example.com:996/captain/img-captain-app-2:1'
+        )
+    })
+
+    test('does not retag third-party or placeholder images', async () => {
+        const dockerApi = {
+            retag: jest.fn().mockResolvedValue(undefined),
+            pullImage: jest.fn().mockResolvedValue(undefined),
+            pushImage: jest.fn().mockResolvedValue(undefined),
+        }
+        const helper = createHelper(dockerApi)
+
+        await helper.retagAndPushImagesForAppRename(
+            [
+                {
+                    version: 0,
+                    gitHash: undefined,
+                    timeStamp: '2024-01-01T00:00:00.000Z',
+                    deployedImageName: 'nginx:1.27',
+                },
+                {
+                    version: 1,
+                    gitHash: undefined,
+                    timeStamp: '2024-01-02T00:00:00.000Z',
+                    deployedImageName:
+                        'caprover/caprover-placeholder-app:latest',
+                },
+            ],
+            'captain',
+            'app-1',
+            'app-2',
+            buildLogs
+        )
+
+        expect(dockerApi.retag).not.toHaveBeenCalled()
+        expect(dockerApi.pushImage).not.toHaveBeenCalled()
+    })
+
+    test('pulls a missing local image from the registry then retags it', async () => {
+        const dockerApi = {
+            retag: jest
+                .fn()
+                .mockRejectedValueOnce(new Error('no such image'))
+                .mockResolvedValueOnce(undefined),
+            pullImage: jest.fn().mockResolvedValue(undefined),
+            pushImage: jest.fn().mockResolvedValue(undefined),
+        }
+        const helper = createHelper(dockerApi, [
+            {
+                id: 'local-reg',
+                registryUser: 'captain',
+                registryPassword: 'secret',
+                registryDomain: 'registry.example.com:996',
+                registryImagePrefix: 'captain',
+                registryType: IRegistryTypes.LOCAL_REG,
+            },
+        ])
+
+        await helper.retagAndPushImagesForAppRename(
+            [
+                {
+                    version: 1,
+                    gitHash: undefined,
+                    timeStamp: '2024-01-02T00:00:00.000Z',
+                    deployedImageName:
+                        'registry.example.com:996/captain/img-captain-app-1:1',
+                },
+            ],
+            'captain',
+            'app-1',
+            'app-2',
+            buildLogs
+        )
+
+        expect(dockerApi.pullImage).toHaveBeenCalledWith(
+            'registry.example.com:996/captain/img-captain-app-1:1',
+            expect.objectContaining({
+                serveraddress: 'registry.example.com:996',
+            })
+        )
+        expect(dockerApi.retag).toHaveBeenCalledTimes(2)
+        expect(dockerApi.pushImage).toHaveBeenCalledTimes(1)
+    })
+})
+
+describe('ServiceManager.renameApp', () => {
+    test('retags images before removing the old service', async () => {
+        const callOrder: string[] = []
+        const dockerApi = {
+            isServiceRunningByName: jest.fn().mockResolvedValue(true),
+            removeServiceByName: jest.fn().mockImplementation(() => {
+                callOrder.push('remove')
+                return Promise.resolve()
+            }),
+            retag: jest.fn().mockImplementation(() => {
+                callOrder.push('retag')
+                return Promise.resolve()
+            }),
+            pullImage: jest.fn().mockResolvedValue(undefined),
+            pushImage: jest.fn().mockResolvedValue(undefined),
+        }
+        const appsDataStore = {
+            getAppDefinition: jest.fn().mockResolvedValue(createDeployedApp()),
+            getServiceName: jest.fn().mockReturnValue('app-1'),
+            nameAllowedOrThrow: jest.fn(),
+            renameApp: jest.fn().mockResolvedValue(undefined),
+        }
+        const dataStore = {
+            getAppsDataStore: () => appsDataStore,
+            getNameSpace: () => 'captain',
+            getRegistriesDataStore: () => ({
+                getAllRegistries: jest.fn().mockResolvedValue([]),
+                getDefaultPushRegistryId: jest
+                    .fn()
+                    .mockResolvedValue(undefined),
+            }),
+        }
+        const serviceManager = new ServiceManager(
+            dataStore as any,
+            authenticator,
+            dockerApi as any,
+            { rePopulateNginxConfigFile: jest.fn() } as any,
+            {} as any,
+            {} as any
+        )
+        jest.spyOn(
+            serviceManager,
+            'ensureServiceInitedAndUpdated'
+        ).mockResolvedValue(undefined as any)
+
+        await serviceManager.renameApp('app-1', 'app-2')
+
+        expect(dockerApi.retag.mock.calls).toEqual([
+            ['img-captain-app-1:0', 'img-captain-app-2:0'],
+            ['img-captain-app-1:1', 'img-captain-app-2:1'],
+        ])
+        expect(callOrder[0]).toBe('retag')
+        expect(callOrder[callOrder.length - 1]).toBe('remove')
+        expect(appsDataStore.renameApp).toHaveBeenCalledWith(
+            authenticator,
+            'app-1',
+            'app-2'
+        )
+    })
+})


### PR DESCRIPTION
## Summary

- After an app is renamed, CapRover-built image tags still used the old app name. Creating a new app with the old name then overwrote the shared tag, so scaling the renamed app back up could run the wrong image.
- Rewrite CapRover-built image names (local and registry-prefixed) on rename, retag existing images, and persist the new names on stored versions. Third-party images and prefix-adjacent names such as `app-1` vs `app-10` are left unchanged.

Fixes #2211

## Test plan

- [x] `npx jest tests/AppRenameImage.test.ts` (12 tests)
- [ ] Rename a deployed CapRover-built app, then create a new app with the old name and scale the renamed app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * App renaming now updates associated built-image references, including registry-hosted images.
  * Images are retagged and pushed before the old app service is removed.
  * Image tags, digests, third-party images, and placeholders are preserved safely during renaming.
  * Renaming is blocked while an app is actively building or unavailable.

* **Tests**
  * Added coverage for local and registry image renaming, recovery, persistence, and service-rename ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->