### PR TITLE
Release 1.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Available as `edge`
 
 - TBD
 
+## [1.15.4] - 2026-08-30
+
+- Fixed: Backup downloads opening a Not Found page [PR-232](https://github.com/caprover/caprover-frontend/pull/232)
+
 ## [1.15.3] - 2026-08-20
 
 - Fixed: Restored build output when using the BuildKit builder [Issue-2461](https://github.com/caprover/caprover/issues/2461)

--- a/dev-scripts/build_and_push_release.sh
+++ b/dev-scripts/build_and_push_release.sh
@@ -44,7 +44,7 @@ echo $IMAGE_NAME:$CAPROVER_VERSION
 echo "**************************************"
 echo "**************************************"
 
-FRONTEND_COMMIT_HASH=35dccc3e099c06f295f78c50d131fc5def91f995
+FRONTEND_COMMIT_HASH=c9005cc2e5ac1b6816cb983d2d3732338c546a94
 
 ## Building frontend app
 ORIG_DIR=$(pwd)

--- a/src/utils/CaptainConstants.ts
+++ b/src/utils/CaptainConstants.ts
@@ -17,7 +17,7 @@ const CONSTANT_FILE_OVERRIDE_USER =
 const configs = {
     publishedNameOnDockerHub: 'caprover/caprover',
 
-    version: '1.15.3',
+    version: '1.15.4',
 
     defaultMaxLogSize: '512m',
 


### PR DESCRIPTION
## Summary
- Bump CapRover to 1.15.4
- Include the frontend fix for backup downloads
- Add the 1.15.4 changelog entry

## Testing
- `npm run formatter`
- `npm run lint`
- `npm run build`
- `npm test -- --runInBand`