### PR TITLE
Upgrade public-ip to version 8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "morgan": "^1.10.0",
                 "multer": "^2.0.1",
                 "on-finished": "^2.4.1",
-                "public-ip": "^7.0.1",
+                "public-ip": "^8.0.0",
                 "require-from-string": "^2.0.2",
                 "serve-favicon": "~2.5.1",
                 "shell-quote": "^1.8.3",
@@ -2056,18 +2056,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@sindresorhus/is": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
-            "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/is?sponsor=1"
-            }
-        },
         "node_modules/@sinonjs/commons": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -2086,18 +2074,6 @@
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@sinonjs/commons": "^3.0.1"
-            }
-        },
-        "node_modules/@szmarczak/http-timer": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-            "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
-            "license": "MIT",
-            "dependencies": {
-                "defer-to-connect": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=14.16"
             }
         },
         "node_modules/@ts-graphviz/adapter": {
@@ -2373,12 +2349,6 @@
                 "@types/jsonfile": "*",
                 "@types/node": "*"
             }
-        },
-        "node_modules/@types/http-cache-semantics": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-            "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
-            "license": "MIT"
         },
         "node_modules/@types/http-errors": {
             "version": "2.0.5",
@@ -3863,33 +3833,6 @@
                 "qified": "^0.10.1"
             }
         },
-        "node_modules/cacheable-lookup": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-            "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            }
-        },
-        "node_modules/cacheable-request": {
-            "version": "10.2.14",
-            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
-            "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/http-cache-semantics": "^4.0.2",
-                "get-stream": "^6.0.1",
-                "http-cache-semantics": "^4.1.1",
-                "keyv": "^4.5.3",
-                "mimic-response": "^4.0.0",
-                "normalize-url": "^8.0.0",
-                "responselike": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=14.16"
-            }
-        },
         "node_modules/cacheable/node_modules/keyv": {
             "version": "5.6.0",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
@@ -4348,33 +4291,6 @@
                 }
             }
         },
-        "node_modules/decompress-response": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "license": "MIT",
-            "dependencies": {
-                "mimic-response": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/decompress-response/node_modules/mimic-response": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/dedent": {
             "version": "1.7.2",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -4428,15 +4344,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/defer-to-connect": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-            "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/delayed-stream": {
@@ -5486,15 +5393,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/form-data-encoder": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
-            "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14.17"
-            }
-        },
         "node_modules/forwarded": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -5645,6 +5543,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -5733,31 +5632,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/got": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
-            "integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
-            "license": "MIT",
-            "dependencies": {
-                "@sindresorhus/is": "^5.2.0",
-                "@szmarczak/http-timer": "^5.0.1",
-                "cacheable-lookup": "^7.0.0",
-                "cacheable-request": "^10.2.8",
-                "decompress-response": "^6.0.0",
-                "form-data-encoder": "^2.1.2",
-                "get-stream": "^6.0.1",
-                "http2-wrapper": "^2.1.10",
-                "lowercase-keys": "^3.0.0",
-                "p-cancelable": "^3.0.0",
-                "responselike": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/got?sponsor=1"
             }
         },
         "node_modules/graceful-fs": {
@@ -5864,12 +5738,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/http-cache-semantics": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-            "license": "BSD-2-Clause"
-        },
         "node_modules/http-errors": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -5902,19 +5770,6 @@
             },
             "engines": {
                 "node": ">=8.0.0"
-            }
-        },
-        "node_modules/http2-wrapper": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
-            "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
-            "license": "MIT",
-            "dependencies": {
-                "quick-lru": "^5.1.1",
-                "resolve-alpn": "^1.2.0"
-            },
-            "engines": {
-                "node": ">=10.19.0"
             }
         },
         "node_modules/https-proxy-agent": {
@@ -7008,12 +6863,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/json-buffer": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-            "license": "MIT"
-        },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -7113,15 +6962,6 @@
             "dependencies": {
                 "jwa": "^2.0.1",
                 "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/keyv": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-            "license": "MIT",
-            "dependencies": {
-                "json-buffer": "3.0.1"
             }
         },
         "node_modules/leven": {
@@ -7248,18 +7088,6 @@
             "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
             "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
             "license": "Apache-2.0"
-        },
-        "node_modules/lowercase-keys": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-            "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
@@ -7425,18 +7253,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/mimic-response": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
-            "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/minimatch": {
@@ -7768,18 +7584,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/normalize-url": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
-            "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -7891,15 +7695,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/p-cancelable": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
-            "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.20"
             }
         },
         "node_modules/p-limit": {
@@ -8375,17 +8170,16 @@
             }
         },
         "node_modules/public-ip": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/public-ip/-/public-ip-7.0.1.tgz",
-            "integrity": "sha512-DdNcqcIbI0wEeCBcqX+bmZpUCvrDMJHXE553zgyG1MZ8S1a/iCCxmK9iTjjql+SpHSv4cZkmRv5/zGYW93AlCw==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/public-ip/-/public-ip-8.0.0.tgz",
+            "integrity": "sha512-XzVyz98rNQiTRciAC+I4w45fWWxM9KKedDGNtH4unPwBcWo2Y9n7kgPXqlTiWqKN0EFlIIU1i8yrWOy9mxgZ8g==",
             "license": "MIT",
             "dependencies": {
                 "dns-socket": "^4.2.2",
-                "got": "^13.0.0",
                 "is-ip": "^5.0.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -8462,18 +8256,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/quick-lru": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/quote-unquote": {
@@ -8625,12 +8407,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/resolve-alpn": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-            "license": "MIT"
-        },
         "node_modules/resolve-cwd": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -8662,21 +8438,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/responselike": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
-            "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
-            "license": "MIT",
-            "dependencies": {
-                "lowercase-keys": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/restore-cursor": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "morgan": "^1.10.0",
         "multer": "^2.0.1",
         "on-finished": "^2.4.1",
-        "public-ip": "^7.0.1",
+        "public-ip": "^8.0.0",
         "require-from-string": "^2.0.2",
         "serve-favicon": "~2.5.1",
         "shell-quote": "^1.8.3",


### PR DESCRIPTION
## Summary

- upgrade `public-ip` from 7.0.1 to 8.0.0
- remove 21 transitive packages that version 8 no longer needs
- retain CapRover's existing dynamic import, which is compatible with the package's ESM-only distribution

## Compatibility

CapRover runs on Node 24, while `public-ip@8` requires Node 20 or newer. The TypeScript build preserves the dynamic import in the compiled CommonJS output, and a direct runtime smoke test confirms that `publicIpv4` loads correctly.

Madge identifies the ESM-only external package as skipped during dependency-graph traversal. TypeScript compilation and the compiled runtime import both succeed.

## Validation

- `npm ci --ignore-scripts`
- `npm ls public-ip`: 8.0.0
- direct ESM import smoke test
- `npm run lint`
- `npm run build`
- `npm run formatter`
- full suite: 20 suites passed, 130 tests passed, 2 skipped
- `npm audit`: 0 vulnerabilities

The full suite reaches a passing Jest summary locally. Its process then exits 1 because of the pre-existing late Docker socket log ("Cannot log after tests are done"), which also reproduces on clean `master`.